### PR TITLE
Restrict role a transaction executor must have on an output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1263,7 +1263,7 @@ dependencies = [
 
 [[package]]
 name = "dscp-node"
-version = "3.0.1"
+version = "3.1.0"
 dependencies = [
  "bs58",
  "dscp-node-runtime",
@@ -1301,7 +1301,7 @@ dependencies = [
 
 [[package]]
 name = "dscp-node-runtime"
-version = "3.0.1"
+version = "3.1.0"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",
@@ -3926,7 +3926,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-process-validation"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "dscp-pallet-traits",
  "frame-benchmarking",

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ In order to use the API within `polkadot.js` you'll need to configure the follow
       "None": "()",
       "SenderOwnsAllInputs": "()",
       "SenderHasInputRole": "SenderHasInputRoleRestriction",
+      "SenderHasOutputRole": "SenderHasOutputRoleRestriction",
       "FixedNumberOfInputs": "FixedNumberOfInputsRestriction",
       "FixedNumberOfOutputs": "FixedNumberOfOutputsRestriction",
       "FixedInputMetadataValue": "FixedMetadataValueRestriction",
@@ -168,6 +169,10 @@ In order to use the API within `polkadot.js` you'll need to configure the follow
     }
   },
   "SenderHasInputRoleRestriction": {
+    "index": "u32",
+    "role_key": "RoleKey"
+  },
+  "SenderHasOutputRoleRestriction": {
     "index": "u32",
     "role_key": "RoleKey"
   },
@@ -243,10 +248,16 @@ pub fn disable_process(origin: OriginFor<T>) -> DispatchResultWithPostInfo;
 
 The pallet defines various type of process restrictions that can be applied to a process. These include:
 
-| Restriction           |                                              description                                               |
-| :-------------------- | :----------------------------------------------------------------------------------------------------: |
-| `None`                |                            Default `Restriction` value that always succeeds                            |
-| `SenderOwnsAllInputs` | Restriction that requires that the process `sender` is assigned the `default` role on all input tokens |
+| Restriction                |                                                     description                                                      |
+| :------------------------- | :------------------------------------------------------------------------------------------------------------------: |
+| `None`                     |                                   Default `Restriction` value that always succeeds                                   |
+| `SenderOwnsAllInputs`      |                Requires that the process `sender` is assigned the `default` role on all input tokens                 |
+| `SenderHasInputRole`       |       Requires that the process `sender` is assigned to a specified role on a specified (by index) input token       |
+| `SenderHasOutputRole`      |      Requires that the process `sender` is assigned to a specified role on a specified (by index) output token       |
+| `FixedNumberOfInputs`      |                            Requires that the number of inputs must be a specified integer                            |
+| `FixedNumberOfOutputs`     |                           Requires that the number of outputs must be a specified integer                            |
+| `FixedInputMetadataValue`  | Requires that a metadata item of a specified key must have a specified value, on a specified (by index) input token  |
+| `FixedOutputMetadataValue` | Requires that a metadata item of a specified key must have a specified value, on a specified (by index) output token |
 
 ### IPFSKey pallet
 

--- a/api/lib/api.js
+++ b/api/lib/api.js
@@ -65,6 +65,7 @@ const api = ({ options }) => {
         None: '()',
         SenderOwnsAllInputs: '()',
         SenderHasInputRole: 'SenderHasInputRoleRestriction',
+        SenderHasOutputRole: 'SenderHasOutputRoleRestriction',
         FixedNumberOfInputs: 'FixedNumberOfInputsRestriction',
         FixedNumberOfOutputs: 'FixedNumberOfOutputsRestriction',
         FixedInputMetadataValue: 'FixedMetadataValueRestriction',
@@ -72,6 +73,10 @@ const api = ({ options }) => {
       },
     },
     SenderHasInputRoleRestriction: {
+      index: 'u32',
+      role_key: 'RoleKey',
+    },
+    SenderHasOutputRoleRestriction: {
       index: 'u32',
       role_key: 'RoleKey',
     },

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-node",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-node",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "license": "ISC",
       "dependencies": {
         "@polkadot/api": "^5.9.1"

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-node",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "DSCP node types",
   "repository": {
     "type": "git",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -6,7 +6,7 @@ edition = '2018'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/dscp-node/'
 name = 'dscp-node'
-version = '3.0.1'
+version = '3.1.0'
 
 [[bin]]
 name = 'dscp-node'

--- a/pallets/process-validation/Cargo.toml
+++ b/pallets/process-validation/Cargo.toml
@@ -5,7 +5,7 @@ edition = '2018'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/dscp-node/'
 name = 'pallet-process-validation'
-version = "2.0.0"
+version = "2.1.0"
 
 
 [package.metadata.docs.rs]

--- a/pallets/process-validation/src/restrictions.rs
+++ b/pallets/process-validation/src/restrictions.rs
@@ -20,6 +20,10 @@ where
         index: u32,
         role_key: RoleKey,
     },
+    SenderHasOutputRole {
+        index: u32,
+        role_key: RoleKey,
+    },
     FixedNumberOfInputs {
         num_inputs: u32,
     },
@@ -87,6 +91,13 @@ where
         Restriction::SenderHasInputRole { index, role_key } => {
             let selected_input = &inputs[index as usize];
             match selected_input.roles.get(&role_key) {
+                Some(account) => sender == account,
+                None => false,
+            }
+        }
+        Restriction::SenderHasOutputRole { index, role_key } => {
+            let selected_output = &outputs[index as usize];
+            match selected_output.roles.get(&role_key) {
                 Some(account) => sender == account,
                 None => false,
             }
@@ -704,6 +715,91 @@ mod tests {
             &1,
             &inputs,
             &Vec::new(),
+        );
+        assert!(!result);
+    }
+
+    #[test]
+    fn sender_has_output_role_succeeds() {
+        let roles = BTreeMap::from_iter(vec![(Default::default(), 1)]);
+        let outputs = vec![ProcessIO {
+            roles: roles.clone(),
+            metadata: BTreeMap::new(),
+            parent_index: None,
+        }];
+        let result = validate_restriction::<u64, u32, u32, u64>(
+            Restriction::SenderHasOutputRole {
+                index: 0,
+                role_key: Default::default(),
+            },
+            &1,
+            &Vec::new(),
+            &outputs,
+        );
+        assert!(result);
+    }
+
+    #[test]
+    fn sender_has_output_role_incorrect_account_id_fails() {
+        let roles = BTreeMap::from_iter(vec![(Default::default(), 2)]);
+        let outputs = vec![ProcessIO {
+            roles: roles.clone(),
+            metadata: BTreeMap::new(),
+            parent_index: None,
+        }];
+        let result = validate_restriction::<u64, u32, u32, u64>(
+            Restriction::SenderHasOutputRole {
+                index: 0,
+                role_key: Default::default(),
+            },
+            &1,
+            &Vec::new(),
+            &outputs,
+        );
+        assert!(!result);
+    }
+
+    #[test]
+    fn sender_has_output_role_incorrect_index_fails() {
+        let roles0 = BTreeMap::from_iter(vec![(Default::default(), 1)]);
+        let roles1 = BTreeMap::from_iter(vec![(Default::default(), 2)]);
+        let outputs = vec![
+            ProcessIO {
+                roles: roles0.clone(),
+                metadata: BTreeMap::new(),
+                parent_index: None,
+            },
+            ProcessIO {
+                roles: roles1.clone(),
+                metadata: BTreeMap::new(),
+                parent_index: None,
+            },
+        ];
+        let result = validate_restriction::<u64, u32, u32, u64>(
+            Restriction::SenderHasOutputRole {
+                index: 1,
+                role_key: Default::default(),
+            },
+            &1,
+            &Vec::new(),
+            &outputs,
+        );
+        assert!(!result);
+    }
+
+    #[test]
+    fn sender_has_output_role_incorrect_role_fails() {
+        let roles = BTreeMap::from_iter(vec![(Default::default(), 1), (0, 1), (1, 2)]);
+        let outputs = vec![ProcessIO {
+            roles: roles.clone(),
+            metadata: BTreeMap::new(),
+            parent_index: None,
+        }];
+        let result = validate_restriction::<u64, u32, u32, u64>(
+            Restriction::SenderHasOutputRole { index: 0, role_key: 1 },
+            &1,
+            &Vec::new(),
+            &outputs,
         );
         assert!(!result);
     }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -4,7 +4,7 @@ edition = '2018'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/dscp-node/'
 name = 'dscp-node-runtime'
-version = '3.0.1'
+version = '3.1.0'
 
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']
@@ -26,7 +26,7 @@ serde = { features = ['derive'], optional = true, version = '1.0.101' }
 
 # local dependencies
 pallet-simple-nft = { version = '3.0.0', default-features = false, package = 'pallet-simple-nft', path = '../pallets/simple-nft' }
-pallet-process-validation = { version = '2.0.0', default-features = false, package = 'pallet-process-validation', path = '../pallets/process-validation' }
+pallet-process-validation = { version = '2.1.0', default-features = false, package = 'pallet-process-validation', path = '../pallets/process-validation' }
 pallet-symmetric-key = { version = '1.0.1', default-features = false, package = 'pallet-symmetric-key', path = '../pallets/symmetric-key' }
 frame-benchmarking = { default-features = false, optional = true, version = '3.0.0' }
 frame-executive = { default-features = false, version = '3.0.0' }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -93,7 +93,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("dscp"),
     impl_name: create_runtime_str!("dscp"),
     authoring_version: 1,
-    spec_version: 300,
+    spec_version: 310,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
Allow restriction on the identity of a named role on an output to the sender of a run_process transaction

![image](https://user-images.githubusercontent.com/40722025/163382369-c626030c-4ffd-42e5-8df8-bf89e8e4fba9.png)
