### PR TITLE
Restrict output metadata value type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1263,7 +1263,7 @@ dependencies = [
 
 [[package]]
 name = "dscp-node"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "bs58",
  "dscp-node-runtime",
@@ -1301,7 +1301,7 @@ dependencies = [
 
 [[package]]
 name = "dscp-node-runtime"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",
@@ -1337,6 +1337,8 @@ dependencies = [
  "sp-std",
  "sp-transaction-pool",
  "sp-version",
+ "strum 0.24.0",
+ "strum_macros 0.24.0",
  "substrate-wasm-builder",
 ]
 
@@ -2186,6 +2188,12 @@ checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -3926,7 +3934,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-process-validation"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "dscp-pallet-traits",
  "frame-benchmarking",
@@ -4649,7 +4657,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32d3ebd75ac2679c2af3a92246639f9fcc8a442ee420719cc4fe195b98dd5fa3"
 dependencies = [
  "bytes 1.0.1",
- "heck",
+ "heck 0.3.3",
  "itertools",
  "log",
  "multimap",
@@ -5139,6 +5147,12 @@ dependencies = [
  "schannel",
  "security-framework",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
 
 [[package]]
 name = "rw-stream-sink"
@@ -6824,7 +6838,7 @@ dependencies = [
  "lazy_static",
  "sp-core",
  "sp-runtime",
- "strum",
+ "strum 0.20.0",
 ]
 
 [[package]]
@@ -7192,7 +7206,7 @@ version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ba9cdfda491b814720b6b06e0cac513d922fc407582032e8706e9f137976f90"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -7205,8 +7219,14 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7318c509b5ba57f18533982607f24070a55d353e90d4cae30c467cdb2ad5ac5c"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.20.1",
 ]
+
+[[package]]
+name = "strum"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e96acfc1b70604b8b2f1ffa4c57e59176c7dbb05d556c71ecd2f5498a1dee7f8"
 
 [[package]]
 name = "strum_macros"
@@ -7214,9 +7234,22 @@ version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee8bc6b87a5112aeeab1f4a9f7ab634fe6cbefc4850006df31267f4cfb9e3149"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro2",
  "quote",
+ "syn",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6878079b17446e4d3eba6192bb0a2950d5b14f0ed8424b852310e5a94345d0ef"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
  "syn",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1263,7 +1263,7 @@ dependencies = [
 
 [[package]]
 name = "dscp-node"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "bs58",
  "dscp-node-runtime",
@@ -1301,7 +1301,7 @@ dependencies = [
 
 [[package]]
 name = "dscp-node-runtime"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",
@@ -3934,7 +3934,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-process-validation"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "dscp-pallet-traits",
  "frame-benchmarking",

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,9 @@ WORKDIR /tmp/
 RUN curl -L https://github.com/gruntwork-io/fetch/releases/download/v0.4.2/fetch_linux_amd64 --output ./fetch && chmod +x ./fetch
 
 ARG DSCP_VERSION=latest
+ARG DSCP_REPO=https://github.com/digicatapult/dscp-node
 
-RUN ./fetch --repo="https://github.com/digicatapult/dscp-node" --tag="${DSCP_VERSION}" --release-asset="dscp-node-.*-x86_64-unknown-linux-gnu.tar.gz" ./ \
+RUN ./fetch --repo="${DSCP_REPO}" --tag="${DSCP_VERSION}" --release-asset="dscp-node-.*-x86_64-unknown-linux-gnu.tar.gz" ./ \
   && mkdir ./dscp-node \
   && tar -xzf ./dscp-node-*-x86_64-unknown-linux-gnu.tar.gz -C ./dscp-node
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ In order to use the API within `polkadot.js` you'll need to configure the follow
       "None": null
     }
   },
+  "MetadataValueType": {
+      "_enum": ["File", "Literal", "TokenId", "None"],
+  },
   "Role": {
     "_enum": [
       "Owner",
@@ -158,15 +161,16 @@ In order to use the API within `polkadot.js` you'll need to configure the follow
   },
   "Restriction": {
     "_enum": {
-      "None": "()",
-      "SenderOwnsAllInputs": "()",
-      "SenderHasInputRole": "SenderHasInputRoleRestriction",
-      "SenderHasOutputRole": "SenderHasOutputRoleRestriction",
-      "OutputHasRole": "OutputHasRoleRestriction",
-      "FixedNumberOfInputs": "FixedNumberOfInputsRestriction",
-      "FixedNumberOfOutputs": "FixedNumberOfOutputsRestriction",
-      "FixedInputMetadataValue": "FixedMetadataValueRestriction",
-      "FixedOutputMetadataValue": "FixedMetadataValueRestriction"
+        "None": "()",
+        "SenderOwnsAllInputs": "()",
+        "SenderHasInputRole": "SenderHasInputRoleRestriction",
+        "SenderHasOutputRole": "SenderHasOutputRoleRestriction",
+        "OutputHasRole": "OutputHasRoleRestriction",
+        "FixedNumberOfInputs": "FixedNumberOfInputsRestriction",
+        "FixedNumberOfOutputs": "FixedNumberOfOutputsRestriction",
+        "FixedInputMetadataValue": "FixedMetadataValueRestriction",
+        "FixedOutputMetadataValue": "FixedMetadataValueRestriction",
+        "FixedOutputMetadataValueType": "FixedOutputMetadataValueType"
     }
   },
   "SenderHasInputRoleRestriction": {
@@ -192,6 +196,11 @@ In order to use the API within `polkadot.js` you'll need to configure the follow
     "metadata_key": "TokenMetadataKey",
     "metadata_value": "TokenMetadataValue"
   },
+  "FixedOutputMetadataValueType": {
+      "index": "u32",
+      "metadata_key": "TokenMetadataKey",
+      "metadata_value_type": "MetadataValueType"
+   },
   "IsNew": "bool",
   "Restrictions": "Vec<Restriction>"
 }
@@ -264,6 +273,7 @@ The pallet defines various type of process restrictions that can be applied to a
 | `FixedNumberOfOutputs`     |                           Requires that the number of outputs must be a specified integer                            |
 | `FixedInputMetadataValue`  | Requires that a metadata item of a specified key must have a specified value, on a specified (by index) input token  |
 | `FixedOutputMetadataValue` | Requires that a metadata item of a specified key must have a specified value, on a specified (by index) output token |
+| `FixedOutputMetadataValueType` | Requires that a metadata item of a specified key must have a value of a specified type, on a specified (by index) output token |
 
 ### IPFSKey pallet
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ In order to use the API within `polkadot.js` you'll need to configure the follow
       "FixedNumberOfOutputs": "FixedNumberOfOutputsRestriction",
       "FixedInputMetadataValue": "FixedMetadataValueRestriction",
       "FixedOutputMetadataValue": "FixedMetadataValueRestriction",
-      "FixedOutputMetadataValueType": "FixedOutputMetadataValueType"
+      "FixedOutputMetadataValueType": "FixedMetadataTypeRestriction"
     }
   },
   "SenderHasInputRoleRestriction": {
@@ -196,7 +196,7 @@ In order to use the API within `polkadot.js` you'll need to configure the follow
     "metadata_key": "TokenMetadataKey",
     "metadata_value": "TokenMetadataValue"
   },
-  "FixedOutputMetadataValueType": {
+  "FixedMetadataTypeRestriction": {
       "index": "u32",
       "metadata_key": "TokenMetadataKey",
       "metadata_value_type": "MetadataValueType"

--- a/README.md
+++ b/README.md
@@ -161,16 +161,16 @@ In order to use the API within `polkadot.js` you'll need to configure the follow
   },
   "Restriction": {
     "_enum": {
-        "None": "()",
-        "SenderOwnsAllInputs": "()",
-        "SenderHasInputRole": "SenderHasInputRoleRestriction",
-        "SenderHasOutputRole": "SenderHasOutputRoleRestriction",
-        "OutputHasRole": "OutputHasRoleRestriction",
-        "FixedNumberOfInputs": "FixedNumberOfInputsRestriction",
-        "FixedNumberOfOutputs": "FixedNumberOfOutputsRestriction",
-        "FixedInputMetadataValue": "FixedMetadataValueRestriction",
-        "FixedOutputMetadataValue": "FixedMetadataValueRestriction",
-        "FixedOutputMetadataValueType": "FixedOutputMetadataValueType"
+      "None": "()",
+      "SenderOwnsAllInputs": "()",
+      "SenderHasInputRole": "SenderHasInputRoleRestriction",
+      "SenderHasOutputRole": "SenderHasOutputRoleRestriction",
+      "OutputHasRole": "OutputHasRoleRestriction",
+      "FixedNumberOfInputs": "FixedNumberOfInputsRestriction",
+      "FixedNumberOfOutputs": "FixedNumberOfOutputsRestriction",
+      "FixedInputMetadataValue": "FixedMetadataValueRestriction",
+      "FixedOutputMetadataValue": "FixedMetadataValueRestriction",
+      "FixedOutputMetadataValueType": "FixedOutputMetadataValueType"
     }
   },
   "SenderHasInputRoleRestriction": {

--- a/api/lib/api.js
+++ b/api/lib/api.js
@@ -44,6 +44,9 @@ const api = ({ options }) => {
         None: null,
       },
     },
+    MetadataValueType: {
+      _enum: ['File', 'Literal', 'TokenId', 'None'],
+    },
     Role: {
       _enum: ['Owner', 'Customer', 'AdditiveManufacturer', 'Laboratory', 'Buyer', 'Supplier', 'Reviewer'],
     },
@@ -70,6 +73,7 @@ const api = ({ options }) => {
         FixedNumberOfOutputs: 'FixedNumberOfOutputsRestriction',
         FixedInputMetadataValue: 'FixedMetadataValueRestriction',
         FixedOutputMetadataValue: 'FixedMetadataValueRestriction',
+        FixedOutputMetadataValueType: 'FixedOutputMetadataValueType',
       },
     },
     SenderHasInputRoleRestriction: {
@@ -90,6 +94,11 @@ const api = ({ options }) => {
       index: 'u32',
       metadata_key: 'TokenMetadataKey',
       metadata_value: 'TokenMetadataValue',
+    },
+    FixedOutputMetadataValueType: {
+      index: 'u32',
+      metadata_key: 'TokenMetadataKey',
+      metadata_value_type: 'MetadataValueType',
     },
     IsNew: 'bool',
     Restrictions: 'Vec<Restriction>',

--- a/api/lib/api.js
+++ b/api/lib/api.js
@@ -74,7 +74,7 @@ const api = ({ options }) => {
         FixedNumberOfOutputs: 'FixedNumberOfOutputsRestriction',
         FixedInputMetadataValue: 'FixedMetadataValueRestriction',
         FixedOutputMetadataValue: 'FixedMetadataValueRestriction',
-        FixedOutputMetadataValueType: 'FixedOutputMetadataValueType',
+        FixedOutputMetadataValueType: 'FixedMetadataTypeRestriction',
       },
     },
     SenderHasInputRoleRestriction: {
@@ -100,7 +100,7 @@ const api = ({ options }) => {
       metadata_key: 'TokenMetadataKey',
       metadata_value: 'TokenMetadataValue',
     },
-    FixedOutputMetadataValueType: {
+    FixedMetadataTypeRestriction: {
       index: 'u32',
       metadata_key: 'TokenMetadataKey',
       metadata_value_type: 'MetadataValueType',

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@digicatapult/dscp-node",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-node",
-      "version": "3.2.0",
-      "license": "ISC",
+      "version": "3.3.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^5.9.1"
       },

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-node",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-node",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "license": "ISC",
       "dependencies": {
         "@polkadot/api": "^5.9.1"

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-node",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "DSCP node types",
   "repository": {
     "type": "git",

--- a/api/package.json
+++ b/api/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@digicatapult/dscp-node",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "DSCP node types",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/digicatapult/dscp-node.git"
   },
   "author": "Digital Catapult",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/digicatapult/dscp-node/issues"
   },

--- a/helm/dscp-node/Chart.yaml
+++ b/helm/dscp-node/Chart.yaml
@@ -6,5 +6,5 @@ maintainers:
     url: www.digicatapult.org.uk
 description: A Helm chart to deploy DSCP nodes
 type: application
-version: 3.2.0
-appVersion: "3.2.0"
+version: 3.3.0
+appVersion: "3.3.0"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -6,7 +6,7 @@ edition = '2018'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/dscp-node/'
 name = 'dscp-node'
-version = '3.2.0'
+version = '3.3.0'
 
 [[bin]]
 name = 'dscp-node'
@@ -25,7 +25,7 @@ structopt = '0.3.8'
 hex-literal = "0.3.1"
 bs58 = "0.4.0"
 
-dscp-node-runtime = { path = '../runtime', version = '3.2.0' }
+dscp-node-runtime = { path = '../runtime', version = '3.3.0' }
 
 # Substrate dependencies
 frame-benchmarking = '3.0.0'

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -6,7 +6,7 @@ edition = '2018'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/dscp-node/'
 name = 'dscp-node'
-version = '3.1.0'
+version = '3.2.0'
 
 [[bin]]
 name = 'dscp-node'
@@ -25,7 +25,7 @@ structopt = '0.3.8'
 hex-literal = "0.3.1"
 bs58 = "0.4.0"
 
-dscp-node-runtime = { path = '../runtime', version = '3.0.0' }
+dscp-node-runtime = { path = '../runtime', version = '3.2.0' }
 
 # Substrate dependencies
 frame-benchmarking = '3.0.0'

--- a/pallets/process-validation/Cargo.toml
+++ b/pallets/process-validation/Cargo.toml
@@ -5,7 +5,7 @@ edition = '2018'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/dscp-node/'
 name = 'pallet-process-validation'
-version = "2.2.0"
+version = "2.3.0"
 
 
 [package.metadata.docs.rs]

--- a/pallets/process-validation/Cargo.toml
+++ b/pallets/process-validation/Cargo.toml
@@ -5,7 +5,7 @@ edition = '2018'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/dscp-node/'
 name = 'pallet-process-validation'
-version = "2.1.0"
+version = "2.2.0"
 
 
 [package.metadata.docs.rs]

--- a/pallets/process-validation/src/lib.rs
+++ b/pallets/process-validation/src/lib.rs
@@ -33,21 +33,23 @@ impl Default for ProcessStatus {
 
 #[derive(Encode, Decode, Clone, PartialEq)]
 #[cfg_attr(feature = "std", derive(Debug))]
-pub struct Process<RoleKey, TokenMetadataKey, TokenMetadataValue>
+pub struct Process<RoleKey, TokenMetadataKey, TokenMetadataValue, TokenMetadataValueDiscriminator>
 where
     RoleKey: Parameter + Default + Ord,
     TokenMetadataKey: Parameter + Default + Ord,
     TokenMetadataValue: Parameter + Default,
+    TokenMetadataValueDiscriminator: Parameter + Default + From<TokenMetadataValue>,
 {
     status: ProcessStatus,
-    restrictions: Vec<Restriction<RoleKey, TokenMetadataKey, TokenMetadataValue>>,
+    restrictions: Vec<Restriction<RoleKey, TokenMetadataKey, TokenMetadataValue, TokenMetadataValueDiscriminator>>,
 }
 
-impl<RoleKey, TokenMetadataKey, TokenMetadataValue> Default for Process<RoleKey, TokenMetadataKey, TokenMetadataValue>
+impl<RoleKey, TokenMetadataKey, TokenMetadataValue, TokenMetadataValueDiscriminator> Default for Process<RoleKey, TokenMetadataKey, TokenMetadataValue, TokenMetadataValueDiscriminator>
 where
     RoleKey: Parameter + Default + Ord,
     TokenMetadataKey: Parameter + Default + Ord,
     TokenMetadataValue: Parameter + Default,
+    TokenMetadataValueDiscriminator: Parameter + Default + From<TokenMetadataValue>,
 {
     fn default() -> Self {
         Process {
@@ -83,6 +85,7 @@ pub mod pallet {
         type RoleKey: Parameter + Default + Ord;
         type TokenMetadataKey: Parameter + Default + Ord;
         type TokenMetadataValue: Parameter + Default;
+        type TokenMetadataValueDiscriminator: Parameter + Default + From<Self::TokenMetadataValue>;
 
         // Origin for overriding weight calculation implementation
         type WeightInfo: WeightInfo;
@@ -104,7 +107,7 @@ pub mod pallet {
         T::ProcessIdentifier,
         Blake2_128Concat,
         T::ProcessVersion,
-        Process<T::RoleKey, T::TokenMetadataKey, T::TokenMetadataValue>,
+        Process<T::RoleKey, T::TokenMetadataKey, T::TokenMetadataValue, T::TokenMetadataValueDiscriminator>,
         ValueQuery,
     >;
 
@@ -126,7 +129,7 @@ pub mod pallet {
         ProcessCreated(
             T::ProcessIdentifier,
             T::ProcessVersion,
-            Vec<Restriction<T::RoleKey, T::TokenMetadataKey, T::TokenMetadataValue>>,
+            Vec<Restriction<T::RoleKey, T::TokenMetadataKey, T::TokenMetadataValue, T::TokenMetadataValueDiscriminator>>,
             bool,
         ),
         //id, version
@@ -152,7 +155,7 @@ pub mod pallet {
         pub(super) fn create_process(
             origin: OriginFor<T>,
             id: T::ProcessIdentifier,
-            restrictions: Vec<Restriction<T::RoleKey, T::TokenMetadataKey, T::TokenMetadataValue>>,
+            restrictions: Vec<Restriction<T::RoleKey, T::TokenMetadataKey, T::TokenMetadataValue, T::TokenMetadataValueDiscriminator>>,
         ) -> DispatchResultWithPostInfo {
             T::CreateProcessOrigin::ensure_origin(origin)?;
             let version: T::ProcessVersion = Pallet::<T>::update_version(id.clone()).unwrap();
@@ -205,7 +208,7 @@ pub mod pallet {
         pub fn persist_process(
             id: &T::ProcessIdentifier,
             v: &T::ProcessVersion,
-            r: &Vec<Restriction<T::RoleKey, T::TokenMetadataKey, T::TokenMetadataValue>>,
+            r: &Vec<Restriction<T::RoleKey, T::TokenMetadataKey, T::TokenMetadataValue, T::TokenMetadataValueDiscriminator>>,
         ) -> Result<(), Error<T>> {
             return match <ProcessModel<T>>::contains_key(&id, &v) {
                 true => Err(Error::<T>::AlreadyExists),
@@ -277,6 +280,7 @@ impl<T: Config> ProcessValidator<T::AccountId, T::RoleKey, T::TokenMetadataKey, 
                         T::RoleKey,
                         T::TokenMetadataKey,
                         T::TokenMetadataValue,
+                        T::TokenMetadataValueDiscriminator,
                     >(restriction, &sender, &inputs, &outputs);
 
                     if !is_valid {

--- a/pallets/process-validation/src/lib.rs
+++ b/pallets/process-validation/src/lib.rs
@@ -44,7 +44,8 @@ where
     restrictions: Vec<Restriction<RoleKey, TokenMetadataKey, TokenMetadataValue, TokenMetadataValueDiscriminator>>,
 }
 
-impl<RoleKey, TokenMetadataKey, TokenMetadataValue, TokenMetadataValueDiscriminator> Default for Process<RoleKey, TokenMetadataKey, TokenMetadataValue, TokenMetadataValueDiscriminator>
+impl<RoleKey, TokenMetadataKey, TokenMetadataValue, TokenMetadataValueDiscriminator> Default
+    for Process<RoleKey, TokenMetadataKey, TokenMetadataValue, TokenMetadataValueDiscriminator>
 where
     RoleKey: Parameter + Default + Ord,
     TokenMetadataKey: Parameter + Default + Ord,
@@ -129,7 +130,9 @@ pub mod pallet {
         ProcessCreated(
             T::ProcessIdentifier,
             T::ProcessVersion,
-            Vec<Restriction<T::RoleKey, T::TokenMetadataKey, T::TokenMetadataValue, T::TokenMetadataValueDiscriminator>>,
+            Vec<
+                Restriction<T::RoleKey, T::TokenMetadataKey, T::TokenMetadataValue, T::TokenMetadataValueDiscriminator>,
+            >,
             bool,
         ),
         //id, version
@@ -155,7 +158,9 @@ pub mod pallet {
         pub(super) fn create_process(
             origin: OriginFor<T>,
             id: T::ProcessIdentifier,
-            restrictions: Vec<Restriction<T::RoleKey, T::TokenMetadataKey, T::TokenMetadataValue, T::TokenMetadataValueDiscriminator>>,
+            restrictions: Vec<
+                Restriction<T::RoleKey, T::TokenMetadataKey, T::TokenMetadataValue, T::TokenMetadataValueDiscriminator>,
+            >,
         ) -> DispatchResultWithPostInfo {
             T::CreateProcessOrigin::ensure_origin(origin)?;
             let version: T::ProcessVersion = Pallet::<T>::update_version(id.clone()).unwrap();
@@ -208,7 +213,9 @@ pub mod pallet {
         pub fn persist_process(
             id: &T::ProcessIdentifier,
             v: &T::ProcessVersion,
-            r: &Vec<Restriction<T::RoleKey, T::TokenMetadataKey, T::TokenMetadataValue, T::TokenMetadataValueDiscriminator>>,
+            r: &Vec<
+                Restriction<T::RoleKey, T::TokenMetadataKey, T::TokenMetadataValue, T::TokenMetadataValueDiscriminator>,
+            >,
         ) -> Result<(), Error<T>> {
             return match <ProcessModel<T>>::contains_key(&id, &v) {
                 true => Err(Error::<T>::AlreadyExists),

--- a/pallets/process-validation/src/restrictions.rs
+++ b/pallets/process-validation/src/restrictions.rs
@@ -999,7 +999,7 @@ mod tests {
             metadata: BTreeMap::new(),
             parent_index: None,
         }];
-        let result = validate_restriction::<u64, u32, u32, u64>(
+        let result = validate_restriction::<u64, u32, u32, u64, u64>(
             Restriction::OutputHasRole { index: 0, role_key: 1 },
             &1,
             &Vec::new(),
@@ -1016,7 +1016,7 @@ mod tests {
             metadata: BTreeMap::new(),
             parent_index: None,
         }];
-        let result = validate_restriction::<u64, u32, u32, u64>(
+        let result = validate_restriction::<u64, u32, u32, u64, u64>(
             Restriction::OutputHasRole { index: 0, role_key: 2 },
             &1,
             &Vec::new(),
@@ -1041,7 +1041,7 @@ mod tests {
                 parent_index: None,
             },
         ];
-        let result = validate_restriction::<u64, u32, u32, u64>(
+        let result = validate_restriction::<u64, u32, u32, u64, u64>(
             Restriction::OutputHasRole { index: 1, role_key: 1 },
             &1,
             &Vec::new(),

--- a/pallets/process-validation/src/restrictions.rs
+++ b/pallets/process-validation/src/restrictions.rs
@@ -152,7 +152,8 @@ mod tests {
 
     #[test]
     fn no_restriction_succeeds() {
-        let result = validate_restriction::<u64, u32, u32, u64, u64>(Restriction::None, &1u64, &Vec::new(), &Vec::new());
+        let result =
+            validate_restriction::<u64, u32, u32, u64, u64>(Restriction::None, &1u64, &Vec::new(), &Vec::new());
         assert!(result);
     }
 
@@ -183,8 +184,12 @@ mod tests {
                 parent_index: None,
             },
         ];
-        let result =
-            validate_restriction::<u64, u32, u32, u64, u64>(Restriction::SenderOwnsAllInputs, &1u64, &inputs, &Vec::new());
+        let result = validate_restriction::<u64, u32, u32, u64, u64>(
+            Restriction::SenderOwnsAllInputs,
+            &1u64,
+            &inputs,
+            &Vec::new(),
+        );
         assert!(result);
     }
 
@@ -204,8 +209,12 @@ mod tests {
                 parent_index: None,
             },
         ];
-        let result =
-            validate_restriction::<u64, u32, u32, u64, u64>(Restriction::SenderOwnsAllInputs, &1u64, &inputs, &Vec::new());
+        let result = validate_restriction::<u64, u32, u32, u64, u64>(
+            Restriction::SenderOwnsAllInputs,
+            &1u64,
+            &inputs,
+            &Vec::new(),
+        );
         assert!(!result);
     }
 
@@ -227,8 +236,12 @@ mod tests {
                 parent_index: None,
             },
         ];
-        let result =
-            validate_restriction::<u64, u32, u32, u64, u64>(Restriction::SenderOwnsAllInputs, &1u64, &inputs, &Vec::new());
+        let result = validate_restriction::<u64, u32, u32, u64, u64>(
+            Restriction::SenderOwnsAllInputs,
+            &1u64,
+            &inputs,
+            &Vec::new(),
+        );
         assert!(!result);
     }
 
@@ -250,8 +263,12 @@ mod tests {
                 parent_index: None,
             },
         ];
-        let result =
-            validate_restriction::<u64, u32, u32, u64, u64>(Restriction::SenderOwnsAllInputs, &1u64, &inputs, &Vec::new());
+        let result = validate_restriction::<u64, u32, u32, u64, u64>(
+            Restriction::SenderOwnsAllInputs,
+            &1u64,
+            &inputs,
+            &Vec::new(),
+        );
         assert!(!result);
     }
 
@@ -664,19 +681,23 @@ mod tests {
     #[derive(Encode, Decode, Clone, PartialEq, Debug, Eq)]
     pub enum MetadataValue {
         A,
-        B
+        B,
     }
     impl Default for MetadataValue {
-        fn default() -> Self { return MetadataValue::A; }
+        fn default() -> Self {
+            return MetadataValue::A;
+        }
     }
 
     #[derive(Encode, Decode, Clone, PartialEq, Debug, Eq)]
     pub enum MetadataValueDisc {
         AA,
-        BB
+        BB,
     }
     impl Default for MetadataValueDisc {
-        fn default() -> Self { return MetadataValueDisc::AA; }
+        fn default() -> Self {
+            return MetadataValueDisc::AA;
+        }
     }
 
     impl From<MetadataValue> for MetadataValueDisc {
@@ -707,7 +728,7 @@ mod tests {
             Restriction::FixedOutputMetadataValueType {
                 index: 1,
                 metadata_key: 1,
-                metadata_value_type: MetadataValueDisc::AA
+                metadata_value_type: MetadataValueDisc::AA,
             },
             &1u64,
             &Vec::new(),
@@ -735,7 +756,7 @@ mod tests {
             Restriction::FixedOutputMetadataValueType {
                 index: 1,
                 metadata_key: 1,
-                metadata_value_type: MetadataValueDisc::BB
+                metadata_value_type: MetadataValueDisc::BB,
             },
             &1u64,
             &Vec::new(),
@@ -763,7 +784,7 @@ mod tests {
             Restriction::FixedOutputMetadataValueType {
                 index: 0,
                 metadata_key: 1,
-                metadata_value_type: MetadataValueDisc::AA
+                metadata_value_type: MetadataValueDisc::AA,
             },
             &1u64,
             &Vec::new(),
@@ -791,7 +812,7 @@ mod tests {
             Restriction::FixedOutputMetadataValueType {
                 index: 1,
                 metadata_key: 0,
-                metadata_value_type: MetadataValueDisc::AA
+                metadata_value_type: MetadataValueDisc::AA,
             },
             &1u64,
             &Vec::new(),

--- a/pallets/process-validation/src/tests.rs
+++ b/pallets/process-validation/src/tests.rs
@@ -77,13 +77,11 @@ impl Default for ProcessIdentifier {
 
 #[derive(Encode, Decode, Clone, PartialEq, Debug, Eq, Default)]
 pub struct TokenMetadataValueDiscriminator {
-    value: u8
+    value: u8,
 }
 impl From<u128> for TokenMetadataValueDiscriminator {
     fn from(a: u128) -> TokenMetadataValueDiscriminator {
-        return TokenMetadataValueDiscriminator {
-          value: (a % 128) as u8
-        }
+        return TokenMetadataValueDiscriminator { value: (a % 128) as u8 };
     }
 }
 

--- a/pallets/process-validation/src/tests.rs
+++ b/pallets/process-validation/src/tests.rs
@@ -75,6 +75,18 @@ impl Default for ProcessIdentifier {
     }
 }
 
+#[derive(Encode, Decode, Clone, PartialEq, Debug, Eq, Default)]
+pub struct TokenMetadataValueDiscriminator {
+    value: u8
+}
+impl From<u128> for TokenMetadataValueDiscriminator {
+    fn from(a: u128) -> TokenMetadataValueDiscriminator {
+        return TokenMetadataValueDiscriminator {
+          value: (a % 128) as u8
+        }
+    }
+}
+
 impl pallet_process_validation::Config for Test {
     type Event = Event;
     type ProcessIdentifier = ProcessIdentifier;
@@ -86,6 +98,7 @@ impl pallet_process_validation::Config for Test {
     type RoleKey = u32;
     type TokenMetadataKey = u32;
     type TokenMetadataValue = u128;
+    type TokenMetadataValueDiscriminator = TokenMetadataValueDiscriminator;
 }
 
 // This function basically just builds a genesis storage key/value store according to

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -4,7 +4,7 @@ edition = '2018'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/dscp-node/'
 name = 'dscp-node-runtime'
-version = '3.2.0'
+version = '3.3.0'
 
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']
@@ -26,7 +26,7 @@ serde = { features = ['derive'], optional = true, version = '1.0.101' }
 
 # local dependencies
 pallet-simple-nft = { version = '3.0.0', default-features = false, package = 'pallet-simple-nft', path = '../pallets/simple-nft' }
-pallet-process-validation = { version = '2.2.0', default-features = false, package = 'pallet-process-validation', path = '../pallets/process-validation' }
+pallet-process-validation = { version = '2.3.0', default-features = false, package = 'pallet-process-validation', path = '../pallets/process-validation' }
 pallet-symmetric-key = { version = '1.0.1', default-features = false, package = 'pallet-symmetric-key', path = '../pallets/symmetric-key' }
 frame-benchmarking = { default-features = false, optional = true, version = '3.0.0' }
 frame-executive = { default-features = false, version = '3.0.0' }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -4,7 +4,7 @@ edition = '2018'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/dscp-node/'
 name = 'dscp-node-runtime'
-version = '3.1.0'
+version = '3.2.0'
 
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']
@@ -26,7 +26,7 @@ serde = { features = ['derive'], optional = true, version = '1.0.101' }
 
 # local dependencies
 pallet-simple-nft = { version = '3.0.0', default-features = false, package = 'pallet-simple-nft', path = '../pallets/simple-nft' }
-pallet-process-validation = { version = '2.1.0', default-features = false, package = 'pallet-process-validation', path = '../pallets/process-validation' }
+pallet-process-validation = { version = '2.2.0', default-features = false, package = 'pallet-process-validation', path = '../pallets/process-validation' }
 pallet-symmetric-key = { version = '1.0.1', default-features = false, package = 'pallet-symmetric-key', path = '../pallets/symmetric-key' }
 frame-benchmarking = { default-features = false, optional = true, version = '3.0.0' }
 frame-executive = { default-features = false, version = '3.0.0' }
@@ -56,6 +56,8 @@ sp-session = { default-features = false, version = '3.0.0' }
 sp-std = { default-features = false, version = '3.0.0' }
 sp-transaction-pool = { default-features = false, version = '3.0.0' }
 sp-version = { default-features = false, version = '3.0.0' }
+strum = { version = "0.24", features = [] }
+strum_macros = { version = "0.24", features = [] }
 
 [features]
 default = ['std']

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -23,6 +23,7 @@ use sp_std::prelude::*;
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
+use strum_macros::{EnumDiscriminants};
 
 // A few exports that help ease life for downstream crates.
 pub use frame_support::{
@@ -306,7 +307,9 @@ impl Default for Role {
     }
 }
 
-#[derive(Encode, Decode, Clone, PartialEq, Debug, Eq)]
+#[derive(Encode, Decode, Clone, PartialEq, Debug, Eq, EnumDiscriminants)]
+#[strum_discriminants(derive(Encode, Decode))]
+#[strum_discriminants(name(MetadataValueType))]
 pub enum MetadataValue<TokenId> {
     File(Hash),
     Literal([u8; 32]),
@@ -317,6 +320,11 @@ pub enum MetadataValue<TokenId> {
 impl<T> Default for MetadataValue<T> {
     fn default() -> Self {
         MetadataValue::None
+    }
+}
+impl Default for MetadataValueType {
+    fn default() -> Self {
+        MetadataValueType::None
     }
 }
 
@@ -348,6 +356,7 @@ impl pallet_process_validation::Config for Runtime {
     type RoleKey = Role;
     type TokenMetadataKey = TokenMetadataKey;
     type TokenMetadataValue = TokenMetadataValue;
+    type TokenMetadataValueDiscriminator = MetadataValueType;
 }
 
 pub struct DummyChangeMembers;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -23,7 +23,7 @@ use sp_std::prelude::*;
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
-use strum_macros::{EnumDiscriminants};
+use strum_macros::EnumDiscriminants;
 
 // A few exports that help ease life for downstream crates.
 pub use frame_support::{


### PR DESCRIPTION
Allows restricting the type of a metadata value for a specific output key on a specific output index