### PR TITLE
Add boolean binary restriction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1263,7 +1263,7 @@ dependencies = [
 
 [[package]]
 name = "dscp-node"
-version = "3.5.0"
+version = "3.6.0"
 dependencies = [
  "bs58",
  "dscp-node-runtime",
@@ -1301,7 +1301,7 @@ dependencies = [
 
 [[package]]
 name = "dscp-node-runtime"
-version = "3.5.0"
+version = "3.6.0"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",
@@ -3934,7 +3934,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-process-validation"
-version = "2.5.0"
+version = "2.6.0"
 dependencies = [
  "dscp-pallet-traits",
  "frame-benchmarking",

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ In order to use the API within `polkadot.js` you'll need to configure the follow
   "Restriction": {
     "_enum": {
       "None": "()",
-      "BooleanBinary": "BooleanBinaryRestriction",
+      "Combined": "CombinedRestriction",
       "SenderOwnsAllInputs": "()",
       "SenderHasInputRole": "SenderHasInputRoleRestriction",
       "SenderHasOutputRole": "SenderHasOutputRoleRestriction",
@@ -179,7 +179,7 @@ In order to use the API within `polkadot.js` you'll need to configure the follow
       "FixedOutputMetadataValueType": "FixedMetadataTypeRestriction"
     }
   },
-  "BooleanBinaryRestriction": {
+  "CombinedRestriction": {
     "operator": "BinaryOperator",
     "restriction_a": "Box<Restriction>",
     "restriction_b": "Box<Restriction>"
@@ -288,7 +288,7 @@ The pallet defines various type of process restrictions that can be applied to a
 | Restriction                     |                                                                                  description                                                                                   |
 | :------------------------------ | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
 | `None`                          |                                                                Default `Restriction` value that always succeeds                                                                |
-| `BooleanBinary`                 |                            Requires two specified restrictions combined via a specified operator [`AND`, `OR`, `XOR`, `NAND`, `NOR`] returns `true`                            |
+| `Combined`                      |                            Requires two specified restrictions combined via a specified operator [`AND`, `OR`, `XOR`, `NAND`, `NOR`] returns `true`                            |
 | `SenderOwnsAllInputs`           |                                             Requires that the process `sender` is assigned the `default` role on all input tokens                                              |
 | `SenderHasInputRole`            |                                    Requires that the process `sender` is assigned to a specified role on a specified (by index) input token                                    |
 | `SenderHasOutputRole`           |                                   Requires that the process `sender` is assigned to a specified role on a specified (by index) output token                                    |

--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ In order to use the API within `polkadot.js` you'll need to configure the follow
       "None": null
     }
   },
+  "BinaryOperator": {
+    "_enum": ["AND", "OR", "XOR", "NAND", "NOR"]
+  },
   "MetadataValueType": {
     "_enum": ["File", "Literal", "TokenId", "None"]
   },
@@ -162,6 +165,7 @@ In order to use the API within `polkadot.js` you'll need to configure the follow
   "Restriction": {
     "_enum": {
       "None": "()",
+      "BooleanBinary": "BooleanBinaryRestriction",
       "SenderOwnsAllInputs": "()",
       "SenderHasInputRole": "SenderHasInputRoleRestriction",
       "SenderHasOutputRole": "SenderHasOutputRoleRestriction",
@@ -174,6 +178,11 @@ In order to use the API within `polkadot.js` you'll need to configure the follow
       "FixedOutputMetadataValue": "FixedMetadataValueRestriction",
       "FixedOutputMetadataValueType": "FixedMetadataTypeRestriction"
     }
+  },
+  "BooleanBinaryRestriction": {
+    "operator": "BinaryOperator",
+    "restriction_a": "Box<Restriction>",
+    "restriction_b": "Box<Restriction>"
   },
   "SenderHasInputRoleRestriction": {
     "index": "u32",
@@ -279,6 +288,7 @@ The pallet defines various type of process restrictions that can be applied to a
 | Restriction                     |                                                                                  description                                                                                   |
 | :------------------------------ | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
 | `None`                          |                                                                Default `Restriction` value that always succeeds                                                                |
+| `BooleanBinary`                 |                            Requires two specified restrictions combined via a specified operator [`AND`, `OR`, `XOR`, `NAND`, `NOR`] returns `true`                            |
 | `SenderOwnsAllInputs`           |                                             Requires that the process `sender` is assigned the `default` role on all input tokens                                              |
 | `SenderHasInputRole`            |                                    Requires that the process `sender` is assigned to a specified role on a specified (by index) input token                                    |
 | `SenderHasOutputRole`           |                                   Requires that the process `sender` is assigned to a specified role on a specified (by index) output token                                    |

--- a/api/lib/api.js
+++ b/api/lib/api.js
@@ -44,6 +44,9 @@ const api = ({ options }) => {
         None: null,
       },
     },
+    BinaryOperator: {
+      _enum: ['AND', 'OR', 'XOR', 'NAND', 'NOR'],
+    },
     MetadataValueType: {
       _enum: ['File', 'Literal', 'TokenId', 'None'],
     },
@@ -66,6 +69,7 @@ const api = ({ options }) => {
     Restriction: {
       _enum: {
         None: '()',
+        BooleanBinary: 'BooleanBinaryRestriction',
         SenderOwnsAllInputs: '()',
         SenderHasInputRole: 'SenderHasInputRoleRestriction',
         SenderHasOutputRole: 'SenderHasOutputRoleRestriction',
@@ -78,6 +82,11 @@ const api = ({ options }) => {
         FixedOutputMetadataValue: 'FixedMetadataValueRestriction',
         FixedOutputMetadataValueType: 'FixedMetadataTypeRestriction',
       },
+    },
+    BooleanBinaryRestriction: {
+      operator: 'BinaryOperator',
+      restriction_a: 'Box<Restriction>',
+      restriction_b: 'Box<Restriction>',
     },
     SenderHasInputRoleRestriction: {
       index: 'u32',

--- a/api/lib/api.js
+++ b/api/lib/api.js
@@ -69,7 +69,7 @@ const api = ({ options }) => {
     Restriction: {
       _enum: {
         None: '()',
-        BooleanBinary: 'BooleanBinaryRestriction',
+        Combined: 'CombinedRestriction',
         SenderOwnsAllInputs: '()',
         SenderHasInputRole: 'SenderHasInputRoleRestriction',
         SenderHasOutputRole: 'SenderHasOutputRoleRestriction',
@@ -83,7 +83,7 @@ const api = ({ options }) => {
         FixedOutputMetadataValueType: 'FixedMetadataTypeRestriction',
       },
     },
-    BooleanBinaryRestriction: {
+    CombinedRestriction: {
       operator: 'BinaryOperator',
       restriction_a: 'Box<Restriction>',
       restriction_b: 'Box<Restriction>',

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-node",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-node",
-      "version": "3.5.0",
+      "version": "3.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^5.9.1"

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-node",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "DSCP node types",
   "repository": {
     "type": "git",

--- a/helm/dscp-node/Chart.yaml
+++ b/helm/dscp-node/Chart.yaml
@@ -6,5 +6,5 @@ maintainers:
     url: www.digicatapult.org.uk
 description: A Helm chart to deploy DSCP nodes
 type: application
-version: 3.5.0
-appVersion: "3.5.0"
+version: 3.6.0
+appVersion: "3.6.0"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -6,7 +6,7 @@ edition = '2018'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/dscp-node/'
 name = 'dscp-node'
-version = '3.5.0'
+version = '3.6.0'
 
 [[bin]]
 name = 'dscp-node'
@@ -25,7 +25,7 @@ structopt = '0.3.8'
 hex-literal = "0.3.1"
 bs58 = "0.4.0"
 
-dscp-node-runtime = { path = '../runtime', version = '3.5.0' }
+dscp-node-runtime = { path = '../runtime', version = '3.6.0' }
 
 # Substrate dependencies
 frame-benchmarking = '3.0.0'

--- a/pallets/process-validation/Cargo.toml
+++ b/pallets/process-validation/Cargo.toml
@@ -5,7 +5,7 @@ edition = '2018'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/dscp-node/'
 name = 'pallet-process-validation'
-version = "2.5.0"
+version = "2.6.0"
 
 
 [package.metadata.docs.rs]

--- a/pallets/process-validation/src/lib.rs
+++ b/pallets/process-validation/src/lib.rs
@@ -213,7 +213,7 @@ pub mod pallet {
                 T::TokenMetadataValue,
                 T::TokenMetadataValueDiscriminator
             >,
-            mut count: u8,
+            count: u8,
             max_depth: u8
         ) -> bool {
             if count > max_depth {
@@ -221,14 +221,14 @@ pub mod pallet {
             }
 
             match restriction {
-                Restriction::BooleanBinary {
+                Restriction::Combined {
                     operator: _,
                     restriction_a,
                     restriction_b
                 } => {
-                    count += 1;
-                    Pallet::<T>::restriction_over_max_depth(*restriction_a, count.clone(), max_depth)
-                        || Pallet::<T>::restriction_over_max_depth(*restriction_b, count.clone(), max_depth)
+                    let incremented_count = count + 1;
+                    Pallet::<T>::restriction_over_max_depth(*restriction_a, incremented_count, max_depth)
+                        || Pallet::<T>::restriction_over_max_depth(*restriction_b, incremented_count, max_depth)
                 }
                 _ => false
             }

--- a/pallets/process-validation/src/lib.rs
+++ b/pallets/process-validation/src/lib.rs
@@ -152,8 +152,8 @@ pub mod pallet {
         AlreadyDisabled,
         // process not found for this versiion
         InvalidVersion,
-        // restriction goes over maximum depth
-        MaxDepth
+        // restrictions go over maximum depth
+        RestrictionsTooDeep
     }
 
     // The pallet's dispatchable functions.
@@ -171,12 +171,8 @@ pub mod pallet {
 
             for restriction in restrictions.iter() {
                 ensure!(
-                    !Pallet::<T>::restriction_over_max_depth(
-                        restriction.clone(),
-                        &mut 0,
-                        T::MaxRestrictionDepth::get()
-                    ),
-                    Error::<T>::MaxDepth
+                    !Pallet::<T>::restriction_over_max_depth(restriction.clone(), 0, T::MaxRestrictionDepth::get()),
+                    Error::<T>::RestrictionsTooDeep
                 );
             }
 
@@ -217,10 +213,10 @@ pub mod pallet {
                 T::TokenMetadataValue,
                 T::TokenMetadataValueDiscriminator
             >,
-            count: &mut u8,
+            mut count: u8,
             max_depth: u8
         ) -> bool {
-            if *count > max_depth {
+            if count > max_depth {
                 return true;
             }
 
@@ -230,9 +226,9 @@ pub mod pallet {
                     restriction_a,
                     restriction_b
                 } => {
-                    *count += 1;
-                    Pallet::<T>::restriction_over_max_depth(*restriction_a, count, max_depth)
-                        || Pallet::<T>::restriction_over_max_depth(*restriction_b, count, max_depth)
+                    count += 1;
+                    Pallet::<T>::restriction_over_max_depth(*restriction_a, count.clone(), max_depth)
+                        || Pallet::<T>::restriction_over_max_depth(*restriction_b, count.clone(), max_depth)
                 }
                 _ => false
             }

--- a/pallets/process-validation/src/lib.rs
+++ b/pallets/process-validation/src/lib.rs
@@ -79,6 +79,9 @@ pub mod pallet {
         type ProcessIdentifier: Parameter;
         type ProcessVersion: Parameter + AtLeast32Bit + Default;
 
+        #[pallet::constant]
+        type MaxRestrictionDepth: Get<u8>;
+
         // Origins for calling these extrinsics. For now these are expected to be root
         type CreateProcessOrigin: EnsureOrigin<Self::Origin>;
         type DisableProcessOrigin: EnsureOrigin<Self::Origin>;
@@ -148,7 +151,9 @@ pub mod pallet {
         // process is already disabled
         AlreadyDisabled,
         // process not found for this versiion
-        InvalidVersion
+        InvalidVersion,
+        // restriction goes over maximum depth
+        MaxDepth
     }
 
     // The pallet's dispatchable functions.
@@ -163,6 +168,18 @@ pub mod pallet {
             >
         ) -> DispatchResultWithPostInfo {
             T::CreateProcessOrigin::ensure_origin(origin)?;
+
+            for restriction in restrictions.iter() {
+                ensure!(
+                    !Pallet::<T>::restriction_over_max_depth(
+                        restriction.clone(),
+                        &mut 0,
+                        T::MaxRestrictionDepth::get()
+                    ),
+                    Error::<T>::MaxDepth
+                );
+            }
+
             let version: T::ProcessVersion = Pallet::<T>::update_version(id.clone()).unwrap();
             Pallet::<T>::persist_process(&id, &version, &restrictions)?;
 
@@ -193,6 +210,34 @@ pub mod pallet {
 
     // helper methods
     impl<T: Config> Pallet<T> {
+        pub fn restriction_over_max_depth(
+            restriction: Restriction<
+                T::RoleKey,
+                T::TokenMetadataKey,
+                T::TokenMetadataValue,
+                T::TokenMetadataValueDiscriminator
+            >,
+            count: &mut u8,
+            max_depth: u8
+        ) -> bool {
+            if *count > max_depth {
+                return true;
+            }
+
+            match restriction {
+                Restriction::BooleanBinary {
+                    operator: _,
+                    restriction_a,
+                    restriction_b
+                } => {
+                    *count += 1;
+                    Pallet::<T>::restriction_over_max_depth(*restriction_a, count, max_depth)
+                        || Pallet::<T>::restriction_over_max_depth(*restriction_b, count, max_depth)
+                }
+                _ => false
+            }
+        }
+
         pub fn get_version(id: &T::ProcessIdentifier) -> T::ProcessVersion {
             return match <VersionModel<T>>::contains_key(&id) {
                 true => <VersionModel<T>>::get(&id) + One::one(),

--- a/pallets/process-validation/src/restrictions.rs
+++ b/pallets/process-validation/src/restrictions.rs
@@ -27,7 +27,7 @@ where
     TokenMetadataValueDiscriminator: Parameter + Default + From<TokenMetadataValue>
 {
     None,
-    BooleanBinary {
+    Combined {
         operator: BinaryOperator,
         restriction_a: Box<Restriction<RoleKey, TokenMetadataKey, TokenMetadataValue, TokenMetadataValueDiscriminator>>,
         restriction_b: Box<Restriction<RoleKey, TokenMetadataKey, TokenMetadataValue, TokenMetadataValueDiscriminator>>
@@ -108,7 +108,7 @@ where
 {
     match restriction {
         Restriction::<R, T, V, D>::None => true,
-        Restriction::BooleanBinary {
+        Restriction::Combined {
             operator,
             restriction_a,
             restriction_b
@@ -1448,7 +1448,7 @@ mod tests {
             parent_index: None
         }];
         let result = validate_restriction::<u64, u32, u32, u64, u64>(
-            Restriction::BooleanBinary {
+            Restriction::Combined {
                 operator: BinaryOperator::AND,
                 restriction_a: {
                     Box::new(Restriction::FixedOutputMetadataValue {
@@ -1480,7 +1480,7 @@ mod tests {
             parent_index: None
         }];
         let result = validate_restriction::<u64, u32, u32, u64, u64>(
-            Restriction::BooleanBinary {
+            Restriction::Combined {
                 operator: BinaryOperator::AND,
                 restriction_a: {
                     Box::new(Restriction::FixedOutputMetadataValue {
@@ -1512,7 +1512,7 @@ mod tests {
             parent_index: None
         }];
         let result = validate_restriction::<u64, u32, u32, u64, u64>(
-            Restriction::BooleanBinary {
+            Restriction::Combined {
                 operator: BinaryOperator::OR,
                 restriction_a: {
                     Box::new(Restriction::FixedOutputMetadataValue {
@@ -1537,6 +1537,38 @@ mod tests {
     }
 
     #[test]
+    fn boolean_binary_or_fails() {
+        let outputs = vec![ProcessIO {
+            roles: BTreeMap::from_iter(vec![(Default::default(), 1)]),
+            metadata: BTreeMap::from_iter(vec![(0, 0)]),
+            parent_index: None
+        }];
+        let result = validate_restriction::<u64, u32, u32, u64, u64>(
+            Restriction::Combined {
+                operator: BinaryOperator::OR,
+                restriction_a: {
+                    Box::new(Restriction::FixedOutputMetadataValue {
+                        index: 0,
+                        metadata_key: 1,
+                        metadata_value: 1
+                    })
+                },
+                restriction_b: {
+                    Box::new(Restriction::FixedOutputMetadataValue {
+                        index: 0,
+                        metadata_key: 2,
+                        metadata_value: 2
+                    })
+                }
+            },
+            &1,
+            &Vec::new(),
+            &outputs
+        );
+        assert!(!result);
+    }
+
+    #[test]
     fn boolean_binary_xor_succeeds() {
         let outputs = vec![ProcessIO {
             roles: BTreeMap::from_iter(vec![(Default::default(), 1)]),
@@ -1544,7 +1576,7 @@ mod tests {
             parent_index: None
         }];
         let result = validate_restriction::<u64, u32, u32, u64, u64>(
-            Restriction::BooleanBinary {
+            Restriction::Combined {
                 operator: BinaryOperator::XOR,
                 restriction_a: {
                     Box::new(Restriction::FixedOutputMetadataValue {
@@ -1576,7 +1608,7 @@ mod tests {
             parent_index: None
         }];
         let result = validate_restriction::<u64, u32, u32, u64, u64>(
-            Restriction::BooleanBinary {
+            Restriction::Combined {
                 operator: BinaryOperator::XOR,
                 restriction_a: {
                     Box::new(Restriction::FixedOutputMetadataValue {
@@ -1608,7 +1640,7 @@ mod tests {
             parent_index: None
         }];
         let result = validate_restriction::<u64, u32, u32, u64, u64>(
-            Restriction::BooleanBinary {
+            Restriction::Combined {
                 operator: BinaryOperator::NAND,
                 restriction_a: {
                     Box::new(Restriction::FixedOutputMetadataValue {
@@ -1640,7 +1672,7 @@ mod tests {
             parent_index: None
         }];
         let result = validate_restriction::<u64, u32, u32, u64, u64>(
-            Restriction::BooleanBinary {
+            Restriction::Combined {
                 operator: BinaryOperator::NAND,
                 restriction_a: {
                     Box::new(Restriction::FixedOutputMetadataValue {
@@ -1672,7 +1704,7 @@ mod tests {
             parent_index: None
         }];
         let result = validate_restriction::<u64, u32, u32, u64, u64>(
-            Restriction::BooleanBinary {
+            Restriction::Combined {
                 operator: BinaryOperator::NOR,
                 restriction_a: {
                     Box::new(Restriction::FixedOutputMetadataValue {
@@ -1704,7 +1736,7 @@ mod tests {
             parent_index: None
         }];
         let result = validate_restriction::<u64, u32, u32, u64, u64>(
-            Restriction::BooleanBinary {
+            Restriction::Combined {
                 operator: BinaryOperator::NOR,
                 restriction_a: {
                     Box::new(Restriction::FixedOutputMetadataValue {

--- a/pallets/process-validation/src/restrictions.rs
+++ b/pallets/process-validation/src/restrictions.rs
@@ -1441,7 +1441,7 @@ mod tests {
     }
 
     #[test]
-    fn boolean_binary_and_succeeds() {
+    fn combined_and_succeeds() {
         let outputs = vec![ProcessIO {
             roles: BTreeMap::from_iter(vec![(Default::default(), 1)]),
             metadata: BTreeMap::from_iter(vec![(0, 0), (1, 1)]),
@@ -1473,7 +1473,7 @@ mod tests {
     }
 
     #[test]
-    fn boolean_binary_and_fails() {
+    fn combined_and_fails() {
         let outputs = vec![ProcessIO {
             roles: BTreeMap::from_iter(vec![(Default::default(), 1)]),
             metadata: BTreeMap::from_iter(vec![(0, 0)]),
@@ -1505,7 +1505,7 @@ mod tests {
     }
 
     #[test]
-    fn boolean_binary_or_succeeds() {
+    fn combined_or_succeeds() {
         let outputs = vec![ProcessIO {
             roles: BTreeMap::from_iter(vec![(Default::default(), 1)]),
             metadata: BTreeMap::from_iter(vec![(0, 0)]),
@@ -1537,7 +1537,7 @@ mod tests {
     }
 
     #[test]
-    fn boolean_binary_or_fails() {
+    fn combined_or_fails() {
         let outputs = vec![ProcessIO {
             roles: BTreeMap::from_iter(vec![(Default::default(), 1)]),
             metadata: BTreeMap::from_iter(vec![(0, 0)]),
@@ -1569,7 +1569,7 @@ mod tests {
     }
 
     #[test]
-    fn boolean_binary_xor_succeeds() {
+    fn combined_xor_succeeds() {
         let outputs = vec![ProcessIO {
             roles: BTreeMap::from_iter(vec![(Default::default(), 1)]),
             metadata: BTreeMap::from_iter(vec![(0, 0)]),
@@ -1601,7 +1601,7 @@ mod tests {
     }
 
     #[test]
-    fn boolean_binary_xor_fails() {
+    fn combined_xor_fails() {
         let outputs = vec![ProcessIO {
             roles: BTreeMap::from_iter(vec![(Default::default(), 1)]),
             metadata: BTreeMap::from_iter(vec![(0, 0), (1, 1)]),
@@ -1633,7 +1633,7 @@ mod tests {
     }
 
     #[test]
-    fn boolean_binary_nand_succeeds() {
+    fn combined_nand_succeeds() {
         let outputs = vec![ProcessIO {
             roles: BTreeMap::from_iter(vec![(Default::default(), 1)]),
             metadata: BTreeMap::new(),
@@ -1665,7 +1665,7 @@ mod tests {
     }
 
     #[test]
-    fn boolean_binary_nand_fails() {
+    fn combined_nand_fails() {
         let outputs = vec![ProcessIO {
             roles: BTreeMap::from_iter(vec![(Default::default(), 1)]),
             metadata: BTreeMap::from_iter(vec![(0, 0), (1, 1)]),
@@ -1697,7 +1697,7 @@ mod tests {
     }
 
     #[test]
-    fn boolean_binary_nor_succeeds() {
+    fn combined_nor_succeeds() {
         let outputs = vec![ProcessIO {
             roles: BTreeMap::from_iter(vec![(Default::default(), 1)]),
             metadata: BTreeMap::new(),
@@ -1729,7 +1729,7 @@ mod tests {
     }
 
     #[test]
-    fn boolean_binary_nor_fails() {
+    fn combined_nor_fails() {
         let outputs = vec![ProcessIO {
             roles: BTreeMap::from_iter(vec![(Default::default(), 1)]),
             metadata: BTreeMap::from_iter(vec![(0, 0)]),

--- a/pallets/process-validation/src/tests.rs
+++ b/pallets/process-validation/src/tests.rs
@@ -70,10 +70,6 @@ pub enum ProcessIdentifier {
     B
 }
 
-// parameter_types! {
-//     pub const MaxRestrictionDepth: u8 = 2;
-// }
-
 impl Default for ProcessIdentifier {
     fn default() -> Self {
         ProcessIdentifier::A

--- a/pallets/process-validation/src/tests.rs
+++ b/pallets/process-validation/src/tests.rs
@@ -36,6 +36,7 @@ frame_support::construct_runtime!(
 parameter_types! {
     pub const BlockHashCount: u64 = 250;
     pub const SS58Prefix: u8 = 42;
+    pub const MaxRestrictionDepth: u8 = 2;
 }
 
 impl system::Config for Test {
@@ -69,6 +70,10 @@ pub enum ProcessIdentifier {
     B
 }
 
+// parameter_types! {
+//     pub const MaxRestrictionDepth: u8 = 2;
+// }
+
 impl Default for ProcessIdentifier {
     fn default() -> Self {
         ProcessIdentifier::A
@@ -92,6 +97,7 @@ impl pallet_process_validation::Config for Test {
     type CreateProcessOrigin = system::EnsureRoot<u64>;
     type DisableProcessOrigin = system::EnsureRoot<u64>;
     type WeightInfo = ();
+    type MaxRestrictionDepth = MaxRestrictionDepth;
 
     type RoleKey = u32;
     type TokenMetadataKey = u32;

--- a/pallets/process-validation/src/tests/create_process.rs
+++ b/pallets/process-validation/src/tests/create_process.rs
@@ -3,7 +3,7 @@ use crate::tests::ProcessIdentifier;
 use crate::Error;
 use crate::Event::*;
 use crate::{
-    BinaryOperator, Process, ProcessModel, ProcessStatus, Restriction::BooleanBinary, Restriction::None, VersionModel
+    BinaryOperator, Process, ProcessModel, ProcessStatus, Restriction::Combined, Restriction::None, VersionModel
 };
 use frame_support::{assert_noop, assert_ok, dispatch::DispatchError};
 
@@ -154,10 +154,10 @@ fn boolean_binary_with_depth_succeeds() {
         assert_ok!(ProcessValidation::create_process(
             Origin::root(),
             PROCESS_ID1,
-            vec![BooleanBinary {
+            vec![Combined {
                 operator: BinaryOperator::AND,
                 restriction_a: { Box::new(None) },
-                restriction_b: Box::new(BooleanBinary {
+                restriction_b: Box::new(Combined {
                     operator: BinaryOperator::AND,
                     restriction_a: { Box::new(None) },
                     restriction_b: { Box::new(None) }
@@ -167,10 +167,10 @@ fn boolean_binary_with_depth_succeeds() {
         let expected = Event::pallet_process_validation(ProcessCreated(
             PROCESS_ID1,
             1u32,
-            vec![BooleanBinary {
+            vec![Combined {
                 operator: BinaryOperator::AND,
                 restriction_a: { Box::new(None) },
-                restriction_b: Box::new(BooleanBinary {
+                restriction_b: Box::new(Combined {
                     operator: BinaryOperator::AND,
                     restriction_a: { Box::new(None) },
                     restriction_b: { Box::new(None) }
@@ -192,13 +192,13 @@ fn boolean_binary_over_max_depth_fails() {
             ProcessValidation::create_process(
                 Origin::root(),
                 PROCESS_ID1,
-                vec![BooleanBinary {
+                vec![Combined {
                     operator: BinaryOperator::AND,
                     restriction_a: { Box::new(None) },
-                    restriction_b: Box::new(BooleanBinary {
+                    restriction_b: Box::new(Combined {
                         operator: BinaryOperator::AND,
                         restriction_a: { Box::new(None) },
-                        restriction_b: Box::new(BooleanBinary {
+                        restriction_b: Box::new(Combined {
                             operator: BinaryOperator::AND,
                             restriction_a: { Box::new(None) },
                             restriction_b: { Box::new(None) }

--- a/pallets/process-validation/src/tests/create_process.rs
+++ b/pallets/process-validation/src/tests/create_process.rs
@@ -2,7 +2,9 @@ use super::*;
 use crate::tests::ProcessIdentifier;
 use crate::Error;
 use crate::Event::*;
-use crate::{Process, ProcessModel, ProcessStatus, Restriction::None, VersionModel};
+use crate::{
+    BinaryOperator, Process, ProcessModel, ProcessStatus, Restriction::BooleanBinary, Restriction::None, VersionModel
+};
 use frame_support::{assert_noop, assert_ok, dispatch::DispatchError};
 
 // -- fixtures --
@@ -142,5 +144,82 @@ fn updates_version_correctly_for_new_process_and_dispatches_event() {
         // sets version to 1 and returns true to identify that this is a new event
         assert_eq!(<VersionModel<Test>>::get(PROCESS_ID1), 1u32);
         assert_eq!(System::events()[0].event, expected);
+    });
+}
+
+#[test]
+fn boolean_binary_with_depth_succeeds() {
+    new_test_ext().execute_with(|| {
+        System::set_block_number(1);
+        assert_ok!(ProcessValidation::create_process(
+            Origin::root(),
+            PROCESS_ID1,
+            vec![BooleanBinary {
+                operator: BinaryOperator::AND,
+                restriction_a: { Box::new(None) },
+                restriction_b: Box::new(BooleanBinary {
+                    operator: BinaryOperator::AND,
+                    restriction_a: { Box::new(None) },
+                    restriction_b: { Box::new(None) }
+                })
+            }]
+        ));
+        let expected = Event::pallet_process_validation(ProcessCreated(
+            PROCESS_ID1,
+            1u32,
+            vec![BooleanBinary {
+                operator: BinaryOperator::AND,
+                restriction_a: { Box::new(None) },
+                restriction_b: Box::new(BooleanBinary {
+                    operator: BinaryOperator::AND,
+                    restriction_a: { Box::new(None) },
+                    restriction_b: { Box::new(None) }
+                })
+            }],
+            true
+        ));
+        // sets version to 1 and returns true to identify that this is a new event
+        assert_eq!(<VersionModel<Test>>::get(PROCESS_ID1), 1u32);
+        assert_eq!(System::events()[0].event, expected);
+    });
+}
+
+#[test]
+fn boolean_binary_over_max_depth_fails() {
+    new_test_ext().execute_with(|| {
+        System::set_block_number(1);
+        assert_noop!(
+            ProcessValidation::create_process(
+                Origin::root(),
+                PROCESS_ID1,
+                vec![BooleanBinary {
+                    operator: BinaryOperator::AND,
+                    restriction_a: { Box::new(None) },
+                    restriction_b: Box::new(BooleanBinary {
+                        operator: BinaryOperator::AND,
+                        restriction_a: { Box::new(None) },
+                        restriction_b: Box::new(BooleanBinary {
+                            operator: BinaryOperator::AND,
+                            restriction_a: { Box::new(None) },
+                            restriction_b: { Box::new(None) }
+                        })
+                    })
+                }]
+            ),
+            DispatchError::Module {
+                index: 1,
+                error: 4,
+                message: Some("RestrictionsTooDeep")
+            },
+        );
+        assert_eq!(<VersionModel<Test>>::get(PROCESS_ID1), 0u32);
+        assert_eq!(
+            <ProcessModel<Test>>::get(PROCESS_ID1, 1u32),
+            Process {
+                status: ProcessStatus::Disabled,
+                restrictions: [].to_vec()
+            }
+        );
+        assert_eq!(System::events().len(), 0);
     });
 }

--- a/pallets/process-validation/src/tests/create_process.rs
+++ b/pallets/process-validation/src/tests/create_process.rs
@@ -148,7 +148,7 @@ fn updates_version_correctly_for_new_process_and_dispatches_event() {
 }
 
 #[test]
-fn boolean_binary_with_depth_succeeds() {
+fn combined_with_depth_succeeds() {
     new_test_ext().execute_with(|| {
         System::set_block_number(1);
         assert_ok!(ProcessValidation::create_process(
@@ -185,7 +185,7 @@ fn boolean_binary_with_depth_succeeds() {
 }
 
 #[test]
-fn boolean_binary_over_max_depth_fails() {
+fn combined_over_max_depth_fails() {
     new_test_ext().execute_with(|| {
         System::set_block_number(1);
         assert_noop!(

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -4,7 +4,7 @@ edition = '2018'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/dscp-node/'
 name = 'dscp-node-runtime'
-version = '3.5.0'
+version = '3.6.0'
 
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']
@@ -26,7 +26,7 @@ serde = { features = ['derive'], optional = true, version = '1.0.101' }
 
 # local dependencies
 pallet-simple-nft = { version = '3.0.1', default-features = false, package = 'pallet-simple-nft', path = '../pallets/simple-nft' }
-pallet-process-validation = { version = '2.5.0', default-features = false, package = 'pallet-process-validation', path = '../pallets/process-validation' }
+pallet-process-validation = { version = '2.6.0', default-features = false, package = 'pallet-process-validation', path = '../pallets/process-validation' }
 pallet-symmetric-key = { version = '1.0.2', default-features = false, package = 'pallet-symmetric-key', path = '../pallets/symmetric-key' }
 frame-benchmarking = { default-features = false, optional = true, version = '3.0.0' }
 frame-executive = { default-features = false, version = '3.0.0' }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -346,6 +346,10 @@ impl pallet_simple_nft::Config for Runtime {
     type MaxMetadataCount = MaxMetadataCount;
 }
 
+parameter_types! {
+    pub const MaxRestrictionDepth: u8 = 3;
+}
+
 impl pallet_process_validation::Config for Runtime {
     type Event = Event;
     type ProcessIdentifier = ProcessIdentifier;
@@ -357,6 +361,7 @@ impl pallet_process_validation::Config for Runtime {
     type TokenMetadataKey = TokenMetadataKey;
     type TokenMetadataValue = TokenMetadataValue;
     type TokenMetadataValueDiscriminator = MetadataValueType;
+    type MaxRestrictionDepth = MaxRestrictionDepth;
 }
 
 pub struct DummyChangeMembers;


### PR DESCRIPTION
Boolean logic (AND/OR/XOR/NOR/NAND) for restrictions so you can logically combine different restrictions together.

- [x] new `Combined` restriction
- [x] `create_process` checks depth of restriction. Maximum set to 3 for runtime.
- [x] tests for restriction and depth check  

![image](https://user-images.githubusercontent.com/40722025/165124236-a96335d2-4dcd-44b8-841e-e3f07f08b2b3.png)