### PR TITLE
Feature/voting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1263,7 +1263,7 @@ dependencies = [
 
 [[package]]
 name = "dscp-node"
-version = "3.6.0"
+version = "3.7.0"
 dependencies = [
  "bs58",
  "dscp-node-runtime",
@@ -1301,7 +1301,7 @@ dependencies = [
 
 [[package]]
 name = "dscp-node-runtime"
-version = "3.6.0"
+version = "3.7.0"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",
@@ -1312,6 +1312,7 @@ dependencies = [
  "hex-literal",
  "pallet-aura",
  "pallet-balances",
+ "pallet-collective",
  "pallet-grandpa",
  "pallet-membership",
  "pallet-node-authorization",
@@ -3875,6 +3876,22 @@ dependencies = [
  "frame-system",
  "parity-scale-codec",
  "serde",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-collective"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe826f3bfb984b3dd8d6675d7d156ba4c0877ee562bf59d86a4e805b7737dcb1"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "serde",
+ "sp-core",
+ "sp-io",
  "sp-runtime",
  "sp-std",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1313,6 +1313,7 @@ dependencies = [
  "pallet-aura",
  "pallet-balances",
  "pallet-collective",
+ "pallet-doas",
  "pallet-grandpa",
  "pallet-membership",
  "pallet-node-authorization",
@@ -3886,6 +3887,21 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe826f3bfb984b3dd8d6675d7d156ba4c0877ee562bf59d86a4e805b7737dcb1"
 dependencies = [
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "serde",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-doas"
+version = "1.0.0"
+dependencies = [
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
  "parity-scale-codec",

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ pub(super) type KeyScheduleId<T: Config> = StorageValue<_, Option<Vec<u8>>, Valu
 
 The first exposes the maintained swarm key, whilst the latter the handle used with the `pallet-scheduling` frame pallet for setting a rotation schedule. This schedule is configured for a 7 day rotation.
 
-Two extrinsics are exposed by this pallet, one for updating a shared symmetric key and one for forcing a rotation of the key based on a configured randomness source. In the `runtime` in this repository these can only be called by `sudo`:
+Two extrinsics are exposed by this pallet, one for updating a shared symmetric key and one for forcing a rotation of the key based on a configured randomness source. In the `runtime` in this repository `update_key` can be called by either `sudo` or a simple majority of the Membership. `rotate_key` can be called either by `sudo` or a pair of accounts in the `Membership` set.
 
 ```rust
 pub(super) fn update_key(origin: OriginFor<T>, new_key: Vec<u8>) -> DispatchResultWithPostInfo { ... }
@@ -330,6 +330,18 @@ Pallet tests can be run with:
 
 ```bash
 cargo test -p pallet-symmetric-key
+```
+
+### Doas pallet
+
+The `Doas` pallet allows for a configurable `Origin` to execute dispatchable functions that require a `Root` call. This is seen as a more flexible of the [`sudo`](https://docs.rs/pallet-sudo/latest/pallet_sudo) pallet provided by ParityTech. This pallet may be used in conjunction with the [`collective`](https://docs.rs/pallet-sudo/latest/pallet_collective) pallet to enable `sudo` like functionality where a majority of the collective must agree to perform the action.
+
+This pallet exposes three extrinsics:
+
+```rust
+pub(super) fn doas_root(origin: OriginFor<T>, call: Box<<T as Config>::Call>) -> DispatchResultWithPostInfo { ... }
+pub(super) fn doas_root_unchecked_weight(origin: OriginFor<T>, call: Box<<T as Config>::Call>, _weight: Weight) -> DispatchResultWithPostInfo { ... }
+pub(super) fn doas(origin: OriginFor<T>, who: <T::Lookup as StaticLookup>::Source, call: Box<<T as Config>::Call>) -> DispatchResultWithPostInfo { ... }
 ```
 
 ## Repo Structure

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-node",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-node",
-      "version": "3.6.0",
+      "version": "3.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^5.9.1"

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-node",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "DSCP node types",
   "repository": {
     "type": "git",

--- a/helm/dscp-node/Chart.yaml
+++ b/helm/dscp-node/Chart.yaml
@@ -6,5 +6,5 @@ maintainers:
     url: www.digicatapult.org.uk
 description: A Helm chart to deploy DSCP nodes
 type: application
-version: 3.6.0
-appVersion: "3.6.0"
+version: 3.7.0
+appVersion: "3.7.0"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -6,7 +6,7 @@ edition = '2018'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/dscp-node/'
 name = 'dscp-node'
-version = '3.6.0'
+version = '3.7.0'
 
 [[bin]]
 name = 'dscp-node'

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -1,5 +1,5 @@
 use dscp_node_runtime::{
-    AccountId, AuraConfig, BalancesConfig, GenesisConfig, GrandpaConfig, MembershipConfig, NodeAuthorizationConfig,
+    AccountId, AuraConfig, BalancesConfig, MembershipConfig, GenesisConfig, GrandpaConfig, NodeAuthorizationConfig,
     Signature, SudoConfig, SystemConfig, WASM_BINARY
 };
 use sc_service::ChainType;
@@ -58,8 +58,12 @@ pub fn development_config() -> Result<ChainSpec, String> {
                 vec![
                     get_account_id_from_seed::<sr25519::Public>("Alice"),
                     get_account_id_from_seed::<sr25519::Public>("Bob"),
-                    get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
-                    get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
+                    get_account_id_from_seed::<sr25519::Public>("Charlie"),
+                ],
+                vec![
+                    get_account_id_from_seed::<sr25519::Public>("Alice"),
+                    get_account_id_from_seed::<sr25519::Public>("Bob"),
+                    get_account_id_from_seed::<sr25519::Public>("Charlie"),
                 ],
                 Some(NodeAuthorizationConfig {
                     nodes: vec![(
@@ -120,12 +124,11 @@ pub fn local_testnet_config() -> Result<ChainSpec, String> {
                     get_account_id_from_seed::<sr25519::Public>("Dave"),
                     get_account_id_from_seed::<sr25519::Public>("Eve"),
                     get_account_id_from_seed::<sr25519::Public>("Ferdie"),
-                    get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
-                    get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
-                    get_account_id_from_seed::<sr25519::Public>("Charlie//stash"),
-                    get_account_id_from_seed::<sr25519::Public>("Dave//stash"),
-                    get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
-                    get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
+                ],
+                vec![
+                    get_account_id_from_seed::<sr25519::Public>("Alice"),
+                    get_account_id_from_seed::<sr25519::Public>("Bob"),
+                    get_account_id_from_seed::<sr25519::Public>("Charlie"),
                 ],
                 Some(NodeAuthorizationConfig {
                     nodes: vec![
@@ -189,6 +192,7 @@ fn testnet_genesis(
     initial_authorities: Vec<(AuraId, GrandpaId)>,
     root_key: AccountId,
     endowed_accounts: Vec<AccountId>,
+    technical_committee_accounts: Vec<AccountId>,
     node_authorization_config: Option<NodeAuthorizationConfig>,
     _enable_println: bool
 ) -> GenesisConfig {
@@ -214,8 +218,9 @@ fn testnet_genesis(
         }),
         pallet_node_authorization: node_authorization_config,
         pallet_membership: Some(MembershipConfig {
-            members: endowed_accounts.iter().map(|k| k.clone()).collect(),
+            members: technical_committee_accounts.iter().cloned().collect(),
             ..Default::default()
-        })
+        }),
+        pallet_collective: Some(Default::default())
     }
 }

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -1,5 +1,5 @@
 use dscp_node_runtime::{
-    AccountId, AuraConfig, BalancesConfig, MembershipConfig, GenesisConfig, GrandpaConfig, NodeAuthorizationConfig,
+    AccountId, AuraConfig, BalancesConfig, GenesisConfig, GrandpaConfig, MembershipConfig, NodeAuthorizationConfig,
     Signature, SudoConfig, SystemConfig, WASM_BINARY
 };
 use sc_service::ChainType;

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -217,10 +217,10 @@ fn testnet_genesis(
             key: root_key
         }),
         pallet_node_authorization: node_authorization_config,
-        pallet_membership: Some(MembershipConfig {
+        pallet_membership_Instance1: Some(MembershipConfig {
             members: technical_committee_accounts.iter().cloned().collect(),
             ..Default::default()
         }),
-        pallet_collective: Some(Default::default())
+        pallet_collective_Instance1: Some(Default::default())
     }
 }

--- a/pallets/doas/Cargo.toml
+++ b/pallets/doas/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "pallet-doas"
+version = "1.0.0"
+authors = ["Digital Catapult <https://www.digicatapult.org.uk>", "Parity Technologies <admin@parity.io>"]
+edition = "2018"
+license = "Apache-2.0"
+repository = "https://github.com/digicatapult/dscp-node/"
+description = "FRAME pallet for doas"
+readme = "README.md"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+serde = { version = "1.0.101", optional = true }
+codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
+frame-support = { default-features = false, version = '3.0.0' }
+frame-system = { default-features = false, version = '3.0.0' }
+frame-benchmarking = { default-features = false, optional = true, version = '3.0.0' }
+sp-runtime = { default-features = false, version = '3.0.0' }
+sp-io = { default-features = false, version = '3.0.0' }
+sp-std = { default-features = false, version = '3.0.0' }
+
+[dev-dependencies]
+sp-core = { default-features = false, version = '3.0.0' }
+
+[features]
+default = ["std"]
+std = [
+	"serde",
+	"codec/std",
+	"sp-std/std",
+	"sp-io/std",
+	"sp-runtime/std",
+	"frame-support/std",
+	"frame-system/std",
+]

--- a/pallets/doas/README.md
+++ b/pallets/doas/README.md
@@ -1,0 +1,70 @@
+# Sudo Module
+
+- [`sudo::Trait`](https://docs.rs/pallet-sudo/latest/pallet_sudo/trait.Trait.html)
+- [`Call`](https://docs.rs/pallet-sudo/latest/pallet_sudo/enum.Call.html)
+
+## Overview
+
+The Sudo module allows for a single account (called the "sudo key")
+to execute dispatchable functions that require a `Root` call
+or designate a new account to replace them as the sudo key.
+Only one account can be the sudo key at a time.
+
+## Interface
+
+### Dispatchable Functions
+
+Only the sudo key can call the dispatchable functions from the Sudo module.
+
+* `sudo` - Make a `Root` call to a dispatchable function.
+* `set_key` - Assign a new account to be the sudo key.
+
+## Usage
+
+### Executing Privileged Functions
+
+The Sudo module itself is not intended to be used within other modules.
+Instead, you can build "privileged functions" (i.e. functions that require `Root` origin) in other modules.
+You can execute these privileged functions by calling `sudo` with the sudo key account.
+Privileged functions cannot be directly executed via an extrinsic.
+
+Learn more about privileged functions and `Root` origin in the [`Origin`] type documentation.
+
+### Simple Code Snippet
+
+This is an example of a module that exposes a privileged function:
+
+```rust
+use frame_support::{decl_module, dispatch};
+use frame_system::ensure_root;
+
+pub trait Config: frame_system::Config {}
+
+decl_module! {
+    pub struct Module<T: Config> for enum Call where origin: T::Origin {
+		#[weight = 0]
+        pub fn privileged_function(origin) -> dispatch::DispatchResult {
+            ensure_root(origin)?;
+
+            // do something...
+
+            Ok(())
+        }
+    }
+}
+```
+
+## Genesis Config
+
+The Sudo module depends on the [`GenesisConfig`](https://docs.rs/pallet-sudo/latest/pallet_sudo/struct.GenesisConfig.html).
+You need to set an initial superuser account as the sudo `key`.
+
+## Related Modules
+
+* [Democracy](https://docs.rs/pallet-democracy/latest/pallet_democracy/)
+
+[`Call`]: ./enum.Call.html
+[`Config`]: ./trait.Config.html
+[`Origin`]: https://docs.substrate.dev/docs/substrate-types
+
+License: Apache-2.0

--- a/pallets/doas/README.md
+++ b/pallets/doas/README.md
@@ -1,8 +1,8 @@
-# Duas Module
+# Doas Module
 
 ## Overview
 
-The Duas module allows for a configurable `Origin`
+The Doas module allows for a configurable `Origin`
 to execute dispatchable functions that require a `Root` call.
 This is seen as a more flexible of the [`sudo`](https://docs.rs/pallet-sudo/latest/pallet_sudo)
 pallet provided by ParityTech. This pallet may be used in conjunction with the
@@ -24,9 +24,9 @@ Only the sudo key can call the dispatchable functions from the Sudo module.
 
 ### Executing Privileged Functions
 
-The Duas module itself is not intended to be used within other modules.
+The Doas module itself is not intended to be used within other modules.
 Instead, you can build "privileged functions" (i.e. functions that require `Root` origin) in other modules.
-You can execute these privileged functions by dispatching `duas` form the configured `Origin`.
+You can execute these privileged functions by dispatching `doas` form the configured `Origin`.
 Privileged functions cannot be directly executed via an extrinsic.
 
 Learn more about privileged functions and `Root` origin in the [`Origin`] type documentation.

--- a/pallets/doas/README.md
+++ b/pallets/doas/README.md
@@ -1,14 +1,14 @@
-# Sudo Module
-
-- [`sudo::Trait`](https://docs.rs/pallet-sudo/latest/pallet_sudo/trait.Trait.html)
-- [`Call`](https://docs.rs/pallet-sudo/latest/pallet_sudo/enum.Call.html)
+# Duas Module
 
 ## Overview
 
-The Sudo module allows for a single account (called the "sudo key")
-to execute dispatchable functions that require a `Root` call
-or designate a new account to replace them as the sudo key.
-Only one account can be the sudo key at a time.
+The Duas module allows for a configurable `Origin`
+to execute dispatchable functions that require a `Root` call.
+This is seen as a more flexible of the [`sudo`](https://docs.rs/pallet-sudo/latest/pallet_sudo)
+pallet provided by ParityTech. This pallet may be used in conjunction with the
+[`collective`](https://docs.rs/pallet-sudo/latest/pallet_collective) pallet
+to enable `sudo` like functionality where a majority of the collective
+must agree to perform the action.
 
 ## Interface
 
@@ -16,16 +16,17 @@ Only one account can be the sudo key at a time.
 
 Only the sudo key can call the dispatchable functions from the Sudo module.
 
-* `sudo` - Make a `Root` call to a dispatchable function.
-* `set_key` - Assign a new account to be the sudo key.
+* `doas_root` - Make a `Root` call to a dispatchable function
+* `doas_root_unchecked_weight` - Make a `Root` call to a dispatchable function overriding weight calculations
+* `doas` - Make a call as a specific user `Origin` to a dispatchable function
 
 ## Usage
 
 ### Executing Privileged Functions
 
-The Sudo module itself is not intended to be used within other modules.
+The Duas module itself is not intended to be used within other modules.
 Instead, you can build "privileged functions" (i.e. functions that require `Root` origin) in other modules.
-You can execute these privileged functions by calling `sudo` with the sudo key account.
+You can execute these privileged functions by dispatching `duas` form the configured `Origin`.
 Privileged functions cannot be directly executed via an extrinsic.
 
 Learn more about privileged functions and `Root` origin in the [`Origin`] type documentation.
@@ -54,17 +55,19 @@ decl_module! {
 }
 ```
 
-## Genesis Config
-
-The Sudo module depends on the [`GenesisConfig`](https://docs.rs/pallet-sudo/latest/pallet_sudo/struct.GenesisConfig.html).
-You need to set an initial superuser account as the sudo `key`.
-
 ## Related Modules
 
+* [Sudo](https://docs.rs/pallet-sudo/latest/pallet_sudo)
+* [Collective]((https://docs.rs/pallet-sudo/latest/pallet_collective)
 * [Democracy](https://docs.rs/pallet-democracy/latest/pallet_democracy/)
 
-[`Call`]: ./enum.Call.html
-[`Config`]: ./trait.Config.html
-[`Origin`]: https://docs.substrate.dev/docs/substrate-types
+# Attribution
+
+`pallet-doas` has been adapted from the version `3.0.0` of the
+[`Sudo`](https://docs.rs/pallet-sudo/latest/pallet_sudo) pallet originally
+licensed under the Apache-2.0 license. A copy of this license can
+be found at [./licenses/pallet-sudo.LICENSE](./licenses/pallet-sudo.LICENSE).
+This module is then relicensed by Digital Catapult under the same Apache-2.0
+license a copy of which is [in the root of this repository](../../LICENSE)
 
 License: Apache-2.0

--- a/pallets/doas/licenses/pallet-sudo.LICENSE
+++ b/pallets/doas/licenses/pallet-sudo.LICENSE
@@ -1,0 +1,211 @@
+                                Apache License
+                        Version 2.0, January 2004
+                    http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+    "License" shall mean the terms and conditions for use, reproduction,
+    and distribution as defined by Sections 1 through 9 of this document.
+
+    "Licensor" shall mean the copyright owner or entity authorized by
+    the copyright owner that is granting the License.
+
+    "Legal Entity" shall mean the union of the acting entity and all
+    other entities that control, are controlled by, or are under common
+    control with that entity. For the purposes of this definition,
+    "control" means (i) the power, direct or indirect, to cause the
+    direction or management of such entity, whether by contract or
+    otherwise, or (ii) ownership of fifty percent (50%) or more of the
+    outstanding shares, or (iii) beneficial ownership of such entity.
+
+    "You" (or "Your") shall mean an individual or Legal Entity
+    exercising permissions granted by this License.
+
+    "Source" form shall mean the preferred form for making modifications,
+    including but not limited to software source code, documentation
+    source, and configuration files.
+
+    "Object" form shall mean any form resulting from mechanical
+    transformation or translation of a Source form, including but
+    not limited to compiled object code, generated documentation,
+    and conversions to other media types.
+
+    "Work" shall mean the work of authorship, whether in Source or
+    Object form, made available under the License, as indicated by a
+    copyright notice that is included in or attached to the work
+    (an example is provided in the Appendix below).
+
+    "Derivative Works" shall mean any work, whether in Source or Object
+    form, that is based on (or derived from) the Work and for which the
+    editorial revisions, annotations, elaborations, or other modifications
+    represent, as a whole, an original work of authorship. For the purposes
+    of this License, Derivative Works shall not include works that remain
+    separable from, or merely link (or bind by name) to the interfaces of,
+    the Work and Derivative Works thereof.
+
+    "Contribution" shall mean any work of authorship, including
+    the original version of the Work and any modifications or additions
+    to that Work or Derivative Works thereof, that is intentionally
+    submitted to Licensor for inclusion in the Work by the copyright owner
+    or by an individual or Legal Entity authorized to submit on behalf of
+    the copyright owner. For the purposes of this definition, "submitted"
+    means any form of electronic, verbal, or written communication sent
+    to the Licensor or its representatives, including but not limited to
+    communication on electronic mailing lists, source code control systems,
+    and issue tracking systems that are managed by, or on behalf of, the
+    Licensor for the purpose of discussing and improving the Work, but
+    excluding communication that is conspicuously marked or otherwise
+    designated in writing by the copyright owner as "Not a Contribution."
+
+    "Contributor" shall mean Licensor and any individual or Legal Entity
+    on behalf of whom a Contribution has been received by Licensor and
+    subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+    this License, each Contributor hereby grants to You a perpetual,
+    worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+    copyright license to reproduce, prepare Derivative Works of,
+    publicly display, publicly perform, sublicense, and distribute the
+    Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+    this License, each Contributor hereby grants to You a perpetual,
+    worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+    (except as stated in this section) patent license to make, have made,
+    use, offer to sell, sell, import, and otherwise transfer the Work,
+    where such license applies only to those patent claims licensable
+    by such Contributor that are necessarily infringed by their
+    Contribution(s) alone or by combination of their Contribution(s)
+    with the Work to which such Contribution(s) was submitted. If You
+    institute patent litigation against any entity (including a
+    cross-claim or counterclaim in a lawsuit) alleging that the Work
+    or a Contribution incorporated within the Work constitutes direct
+    or contributory patent infringement, then any patent licenses
+    granted to You under this License for that Work shall terminate
+    as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+    Work or Derivative Works thereof in any medium, with or without
+    modifications, and in Source or Object form, provided that You
+    meet the following conditions:
+
+    (a) You must give any other recipients of the Work or
+        Derivative Works a copy of this License; and
+
+    (b) You must cause any modified files to carry prominent notices
+        stating that You changed the files; and
+
+    (c) You must retain, in the Source form of any Derivative Works
+        that You distribute, all copyright, patent, trademark, and
+        attribution notices from the Source form of the Work,
+        excluding those notices that do not pertain to any part of
+        the Derivative Works; and
+
+    (d) If the Work includes a "NOTICE" text file as part of its
+        distribution, then any Derivative Works that You distribute must
+        include a readable copy of the attribution notices contained
+        within such NOTICE file, excluding those notices that do not
+        pertain to any part of the Derivative Works, in at least one
+        of the following places: within a NOTICE text file distributed
+        as part of the Derivative Works; within the Source form or
+        documentation, if provided along with the Derivative Works; or,
+        within a display generated by the Derivative Works, if and
+        wherever such third-party notices normally appear. The contents
+        of the NOTICE file are for informational purposes only and
+        do not modify the License. You may add Your own attribution
+        notices within Derivative Works that You distribute, alongside
+        or as an addendum to the NOTICE text from the Work, provided
+        that such additional attribution notices cannot be construed
+        as modifying the License.
+
+    You may add Your own copyright statement to Your modifications and
+    may provide additional or different license terms and conditions
+    for use, reproduction, or distribution of Your modifications, or
+    for any such Derivative Works as a whole, provided Your use,
+    reproduction, and distribution of the Work otherwise complies with
+    the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+    any Contribution intentionally submitted for inclusion in the Work
+    by You to the Licensor shall be under the terms and conditions of
+    this License, without any additional terms or conditions.
+    Notwithstanding the above, nothing herein shall supersede or modify
+    the terms of any separate license agreement you may have executed
+    with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+    names, trademarks, service marks, or product names of the Licensor,
+    except as required for reasonable and customary use in describing the
+    origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+    agreed to in writing, Licensor provides the Work (and each
+    Contributor provides its Contributions) on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied, including, without limitation, any warranties or conditions
+    of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+    PARTICULAR PURPOSE. You are solely responsible for determining the
+    appropriateness of using or redistributing the Work and assume any
+    risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+    whether in tort (including negligence), contract, or otherwise,
+    unless required by applicable law (such as deliberate and grossly
+    negligent acts) or agreed to in writing, shall any Contributor be
+    liable to You for damages, including any direct, indirect, special,
+    incidental, or consequential damages of any character arising as a
+    result of this License or out of the use or inability to use the
+    Work (including but not limited to damages for loss of goodwill,
+    work stoppage, computer failure or malfunction, or any and all
+    other commercial damages or losses), even if such Contributor
+    has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+    the Work or Derivative Works thereof, You may choose to offer,
+    and charge a fee for, acceptance of support, warranty, indemnity,
+    or other liability obligations and/or rights consistent with this
+    License. However, in accepting such obligations, You may act only
+    on Your own behalf and on Your sole responsibility, not on behalf
+    of any other Contributor, and only if You agree to indemnify,
+    defend, and hold each Contributor harmless for any liability
+    incurred by, or claims asserted against, such Contributor by reason
+    of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+    To apply the Apache License to your work, attach the following
+    boilerplate notice, with the fields enclosed by brackets "[]"
+    replaced with your own identifying information. (Don't include
+    the brackets!)  The text should be enclosed in the appropriate
+    comment syntax for the file format. We also recommend that a
+    file or class name and description of purpose be included on the
+    same "printed page" as the copyright notice for easier
+    identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+                                    NOTE
+
+Individual files contain the following tag instead of the full license
+text.
+
+    SPDX-License-Identifier:  Apache-2.0
+
+This enables machine processing of license information based on the SPDX
+License Identifiers that are here available: http://spdx.org/licenses/

--- a/pallets/doas/src/lib.rs
+++ b/pallets/doas/src/lib.rs
@@ -44,9 +44,9 @@ pub mod pallet {
     #[pallet::generate_deposit(pub(super) fn deposit_event)]
     pub enum Event<T: Config> {
         /// A doas_root just took place. \[result\]
-        DoasRootDone(DispatchResult),
+        DidAsRoot(DispatchResult),
         /// A doas just took place. \[result\]
-        DoasDone(DispatchResult),
+        DidAs(DispatchResult),
     }
 
     // The pallet's dispatchable functions.
@@ -71,7 +71,7 @@ pub mod pallet {
           T::DoasOrigin::ensure_origin(origin)?;
 
           let res = call.dispatch_bypass_filter(frame_system::RawOrigin::Root.into());
-          Self::deposit_event(Event::DoasRootDone(res.map(|_| ()).map_err(|e| e.error)));
+          Self::deposit_event(Event::DidAsRoot(res.map(|_| ()).map_err(|e| e.error)));
           // Sudo user does not pay a fee.
           Ok(Pays::No.into())
         }
@@ -92,7 +92,7 @@ pub mod pallet {
           T::DoasOrigin::ensure_origin(origin)?;
 
           let res = call.dispatch_bypass_filter(frame_system::RawOrigin::Root.into());
-          Self::deposit_event(Event::DoasRootDone(res.map(|_| ()).map_err(|e| e.error)));
+          Self::deposit_event(Event::DidAsRoot(res.map(|_| ()).map_err(|e| e.error)));
           // Sudo user does not pay a fee.
           Ok(Pays::No.into())
         }
@@ -129,7 +129,7 @@ pub mod pallet {
 
           let res = call.dispatch_bypass_filter(frame_system::RawOrigin::Signed(who).into());
 
-          Self::deposit_event(Event::DoasDone(res.map(|_| ()).map_err(|e| e.error)));
+          Self::deposit_event(Event::DidAs(res.map(|_| ()).map_err(|e| e.error)));
           // Duas user does not pay a fee.
           Ok(Pays::No.into())
         }

--- a/pallets/doas/src/lib.rs
+++ b/pallets/doas/src/lib.rs
@@ -14,6 +14,11 @@ use frame_support::{
   dispatch::DispatchResultWithPostInfo,
 };
 
+#[cfg(test)]
+mod mock;
+#[cfg(test)]
+mod tests;
+
 #[frame_support::pallet]
 pub mod pallet {
 
@@ -66,7 +71,7 @@ pub mod pallet {
           let dispatch_info = call.get_dispatch_info();
           (dispatch_info.weight.saturating_add(10_000), dispatch_info.class)
         })]
-        fn doas_root(origin: OriginFor<T>, call: Box<<T as Config>::Call>) -> DispatchResultWithPostInfo {
+        pub(super) fn doas_root(origin: OriginFor<T>, call: Box<<T as Config>::Call>) -> DispatchResultWithPostInfo {
           // This is a public call, so we ensure that the origin is some signed account.
           T::DoasOrigin::ensure_origin(origin)?;
 
@@ -87,7 +92,7 @@ pub mod pallet {
         /// - The weight of this call is defined by the caller.
         /// # </weight>
         #[pallet::weight((*_weight, call.get_dispatch_info().class))]
-        fn doas_root_unchecked_weight(origin: OriginFor<T>, call: Box<<T as Config>::Call>, _weight: Weight) -> DispatchResultWithPostInfo {
+        pub(super) fn doas_root_unchecked_weight(origin: OriginFor<T>, call: Box<<T as Config>::Call>, _weight: Weight) -> DispatchResultWithPostInfo {
           // This is a public call, so we ensure that the origin is some signed account.
           T::DoasOrigin::ensure_origin(origin)?;
 
@@ -118,7 +123,7 @@ pub mod pallet {
             dispatch_info.class,
           )
         })]
-        fn doas(origin: OriginFor<T>,
+        pub(super) fn doas(origin: OriginFor<T>,
           who: <T::Lookup as StaticLookup>::Source,
           call: Box<<T as Config>::Call>
         ) -> DispatchResultWithPostInfo {
@@ -130,7 +135,7 @@ pub mod pallet {
           let res = call.dispatch_bypass_filter(frame_system::RawOrigin::Signed(who).into());
 
           Self::deposit_event(Event::DidAs(res.map(|_| ()).map_err(|e| e.error)));
-          // Duas user does not pay a fee.
+          // Doas user does not pay a fee.
           Ok(Pays::No.into())
         }
     }

--- a/pallets/doas/src/lib.rs
+++ b/pallets/doas/src/lib.rs
@@ -1,0 +1,137 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+pub use pallet::*;
+
+use sp_std::prelude::*;
+use sp_runtime::{DispatchResult, traits::StaticLookup};
+
+use frame_support::{
+  Parameter, traits::EnsureOrigin
+};
+use frame_support::{
+  weights::{Weight, GetDispatchInfo, Pays},
+  traits::{UnfilteredDispatchable, Get},
+  dispatch::DispatchResultWithPostInfo,
+};
+
+#[frame_support::pallet]
+pub mod pallet {
+
+    use super::*;
+    use frame_support::pallet_prelude::*;
+    use frame_system::pallet_prelude::*;
+
+    #[pallet::config]
+    pub trait Config: frame_system::Config {
+      /// The overarching event type.
+      type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
+
+      /// A sudo-able call.
+      type Call: Parameter + UnfilteredDispatchable<Origin=Self::Origin> + GetDispatchInfo;
+
+      /// An Origin that is permitted to perform Doas operations
+      type DoasOrigin: EnsureOrigin<Self::Origin>;
+    }
+
+    #[pallet::pallet]
+    #[pallet::generate_store(pub(super) trait Store)]
+    pub struct Pallet<T>(PhantomData<T>);
+
+    #[pallet::hooks]
+    impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+
+    #[pallet::event]
+    #[pallet::generate_deposit(pub(super) fn deposit_event)]
+    pub enum Event<T: Config> {
+        /// A doas_root just took place. \[result\]
+        DoasRootDone(DispatchResult),
+        /// A doas just took place. \[result\]
+        DoasDone(DispatchResult),
+    }
+
+    // The pallet's dispatchable functions.
+    #[pallet::call]
+    impl<T: Config> Pallet<T> {
+        /// Authenticates the sudo key and dispatches a function call with `Root` origin.
+        ///
+        /// The dispatch origin for this call must be _Signed_.
+        ///
+        /// # <weight>
+        /// - O(1).
+        /// - Limited storage reads.
+        /// - One DB write (event).
+        /// - Weight of derivative `call` execution + 10,000.
+        /// # </weight>
+        #[pallet::weight({
+          let dispatch_info = call.get_dispatch_info();
+          (dispatch_info.weight.saturating_add(10_000), dispatch_info.class)
+        })]
+        fn doas_root(origin: OriginFor<T>, call: Box<<T as Config>::Call>) -> DispatchResultWithPostInfo {
+          // This is a public call, so we ensure that the origin is some signed account.
+          T::DoasOrigin::ensure_origin(origin)?;
+
+          let res = call.dispatch_bypass_filter(frame_system::RawOrigin::Root.into());
+          Self::deposit_event(Event::DoasRootDone(res.map(|_| ()).map_err(|e| e.error)));
+          // Sudo user does not pay a fee.
+          Ok(Pays::No.into())
+        }
+
+        /// Authenticates the sudo key and dispatches a function call with `Root` origin.
+        /// This function does not check the weight of the call, and instead allows the
+        /// Sudo user to specify the weight of the call.
+        ///
+        /// The dispatch origin for this call must be _Signed_.
+        ///
+        /// # <weight>
+        /// - O(1).
+        /// - The weight of this call is defined by the caller.
+        /// # </weight>
+        #[pallet::weight((*_weight, call.get_dispatch_info().class))]
+        fn doas_root_unchecked_weight(origin: OriginFor<T>, call: Box<<T as Config>::Call>, _weight: Weight) -> DispatchResultWithPostInfo {
+          // This is a public call, so we ensure that the origin is some signed account.
+          T::DoasOrigin::ensure_origin(origin)?;
+
+          let res = call.dispatch_bypass_filter(frame_system::RawOrigin::Root.into());
+          Self::deposit_event(Event::DoasRootDone(res.map(|_| ()).map_err(|e| e.error)));
+          // Sudo user does not pay a fee.
+          Ok(Pays::No.into())
+        }
+
+        /// Authenticates the sudo key and dispatches a function call with `Signed` origin from
+        /// a given account.
+        ///
+        /// The dispatch origin for this call must be _Signed_.
+        ///
+        /// # <weight>
+        /// - O(1).
+        /// - Limited storage reads.
+        /// - One DB write (event).
+        /// - Weight of derivative `call` execution + 10,000.
+        /// # </weight>
+        #[pallet::weight({
+          let dispatch_info = call.get_dispatch_info();
+          (
+            dispatch_info.weight
+              .saturating_add(10_000)
+              // AccountData for inner call origin accountdata.
+              .saturating_add(T::DbWeight::get().reads_writes(1, 1)),
+            dispatch_info.class,
+          )
+        })]
+        fn doas(origin: OriginFor<T>,
+          who: <T::Lookup as StaticLookup>::Source,
+          call: Box<<T as Config>::Call>
+        ) -> DispatchResultWithPostInfo {
+          // This is a public call, so we ensure that the origin is some signed account.
+          T::DoasOrigin::ensure_origin(origin)?;
+
+          let who = T::Lookup::lookup(who)?;
+
+          let res = call.dispatch_bypass_filter(frame_system::RawOrigin::Signed(who).into());
+
+          Self::deposit_event(Event::DoasDone(res.map(|_| ()).map_err(|e| e.error)));
+          // Duas user does not pay a fee.
+          Ok(Pays::No.into())
+        }
+    }
+}

--- a/pallets/doas/src/mock.rs
+++ b/pallets/doas/src/mock.rs
@@ -18,119 +18,122 @@
 //! Test utilities
 
 use super::*;
-use frame_support::{parameter_types, ord_parameter_types, weights::Weight};
-use sp_core::H256;
-use sp_runtime::{traits::{BlakeTwo256, IdentityLookup}, testing::Header};
-use sp_io;
-use frame_system::EnsureSignedBy;
 use crate as doas;
+use frame_support::{ord_parameter_types, parameter_types, weights::Weight};
+use frame_system::EnsureSignedBy;
+use sp_core::H256;
+use sp_io;
+use sp_runtime::{
+    testing::Header,
+    traits::{BlakeTwo256, IdentityLookup}
+};
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 // Logger module to track execution.
 pub mod logger {
-	use super::*;
-	use frame_system::{ensure_root, ensure_signed};
+    use super::*;
+    use frame_system::{ensure_root, ensure_signed};
 
-	pub trait Config: frame_system::Config {
-		type Event: From<Event<Self>> + Into<<Self as frame_system::Config>::Event>;
-	}
+    pub trait Config: frame_system::Config {
+        type Event: From<Event<Self>> + Into<<Self as frame_system::Config>::Event>;
+    }
 
-	frame_support::decl_storage! {
-		trait Store for Module<T: Config> as Logger {
-			AccountLog get(fn account_log): Vec<T::AccountId>;
-			I32Log get(fn i32_log): Vec<i32>;
-		}
-	}
+    frame_support::decl_storage! {
+        trait Store for Module<T: Config> as Logger {
+            AccountLog get(fn account_log): Vec<T::AccountId>;
+            I32Log get(fn i32_log): Vec<i32>;
+        }
+    }
 
-	frame_support::decl_event! {
-		pub enum Event<T> where AccountId = <T as frame_system::Config>::AccountId {
-			AppendI32(i32, Weight),
-			AppendI32AndAccount(AccountId, i32, Weight),
-		}
-	}
+    frame_support::decl_event! {
+        pub enum Event<T> where AccountId = <T as frame_system::Config>::AccountId {
+            AppendI32(i32, Weight),
+            AppendI32AndAccount(AccountId, i32, Weight),
+        }
+    }
 
-	frame_support::decl_module! {
-		pub struct Module<T: Config> for enum Call where origin: <T as frame_system::Config>::Origin {
-			fn deposit_event() = default;
+    frame_support::decl_module! {
+        pub struct Module<T: Config> for enum Call where origin: <T as frame_system::Config>::Origin {
+            fn deposit_event() = default;
 
-			#[weight = *weight]
-			fn privileged_i32_log(origin, i: i32, weight: Weight){
-				// Ensure that the `origin` is `Root`.
-				ensure_root(origin)?;
-				<I32Log>::append(i);
-				Self::deposit_event(RawEvent::AppendI32(i, weight));
-			}
+            #[weight = *weight]
+            fn privileged_i32_log(origin, i: i32, weight: Weight){
+                // Ensure that the `origin` is `Root`.
+                ensure_root(origin)?;
+                <I32Log>::append(i);
+                Self::deposit_event(RawEvent::AppendI32(i, weight));
+            }
 
-			#[weight = *weight]
-			fn non_privileged_log(origin, i: i32, weight: Weight){
-				// Ensure that the `origin` is some signed account.
-				let sender = ensure_signed(origin)?;
-				<I32Log>::append(i);
-				<AccountLog<T>>::append(sender.clone());
-				Self::deposit_event(RawEvent::AppendI32AndAccount(sender, i, weight));
-			}
-		}
-	}
+            #[weight = *weight]
+            fn non_privileged_log(origin, i: i32, weight: Weight){
+                // Ensure that the `origin` is some signed account.
+                let sender = ensure_signed(origin)?;
+                <I32Log>::append(i);
+                <AccountLog<T>>::append(sender.clone());
+                Self::deposit_event(RawEvent::AppendI32AndAccount(sender, i, weight));
+            }
+        }
+    }
 }
 
 frame_support::construct_runtime!(
-	pub enum Test where
-	Block = Block,
-	NodeBlock = Block,
-	UncheckedExtrinsic = UncheckedExtrinsic,
-	{
-		System: frame_system::{Module, Call, Config, Storage, Event<T>},
-		Doas: doas::{Module, Call, Event<T>},
-		Logger: logger::{Module, Call, Storage, Event<T>},
-	}
+    pub enum Test where
+    Block = Block,
+    NodeBlock = Block,
+    UncheckedExtrinsic = UncheckedExtrinsic,
+    {
+        System: frame_system::{Module, Call, Config, Storage, Event<T>},
+        Doas: doas::{Module, Call, Event<T>},
+        Logger: logger::{Module, Call, Storage, Event<T>},
+    }
 );
 parameter_types! {
-	pub const BlockHashCount: u64 = 250;
-	pub const SS58Prefix: u8 = 42;
+    pub const BlockHashCount: u64 = 250;
+    pub const SS58Prefix: u8 = 42;
 }
 
 impl frame_system::Config for Test {
-	type BaseCallFilter = ();
-	type BlockWeights = ();
-	type BlockLength = ();
-	type DbWeight = ();
-	type Origin = Origin;
-	type Call = Call;
-	type Index = u64;
-	type BlockNumber = u64;
-	type Hash = H256;
-	type Hashing = BlakeTwo256;
-	type AccountId = u64;
-	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
-	type Event = Event;
-	type BlockHashCount = BlockHashCount;
-	type Version = ();
-	type PalletInfo = PalletInfo;
-	type AccountData = ();
-	type OnNewAccount = ();
-	type OnKilledAccount = ();
-	type SystemWeightInfo = ();
-	type SS58Prefix = SS58Prefix;
+    type BaseCallFilter = ();
+    type BlockWeights = ();
+    type BlockLength = ();
+    type DbWeight = ();
+    type Origin = Origin;
+    type Call = Call;
+    type Index = u64;
+    type BlockNumber = u64;
+    type Hash = H256;
+    type Hashing = BlakeTwo256;
+    type AccountId = u64;
+    type Lookup = IdentityLookup<Self::AccountId>;
+    type Header = Header;
+    type Event = Event;
+    type BlockHashCount = BlockHashCount;
+    type Version = ();
+    type PalletInfo = PalletInfo;
+    type AccountData = ();
+    type OnNewAccount = ();
+    type OnKilledAccount = ();
+    type SystemWeightInfo = ();
+    type SS58Prefix = SS58Prefix;
 }
 
 // Implement the logger module's `Config` on the Test runtime.
 impl logger::Config for Test {
-	type Event = Event;
+    type Event = Event;
 }
 
 ord_parameter_types! {
-	pub const One: u64 = 1;
-	pub const Two: u64 = 2;
+    pub const One: u64 = 1;
+    pub const Two: u64 = 2;
 }
 
 // Implement the doas module's `Config` on the Test runtime.
 impl Config for Test {
-	type Event = Event;
-	type Call = Call;
-	type DoasOrigin = EnsureSignedBy<One, u64>;
+    type Event = Event;
+    type Call = Call;
+    type DoasOrigin = EnsureSignedBy<One, u64>;
 }
 
 // New types for dispatchable functions.
@@ -139,5 +142,8 @@ pub type LoggerCall = logger::Call<Test>;
 
 // Build test environment by setting the root `key` for the Genesis.
 pub fn new_test_ext() -> sp_io::TestExternalities {
-	frame_system::GenesisConfig::default().build_storage::<Test>().unwrap().into()
+    frame_system::GenesisConfig::default()
+        .build_storage::<Test>()
+        .unwrap()
+        .into()
 }

--- a/pallets/doas/src/mock.rs
+++ b/pallets/doas/src/mock.rs
@@ -1,0 +1,143 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2020-2021 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Test utilities
+
+use super::*;
+use frame_support::{parameter_types, ord_parameter_types, weights::Weight};
+use sp_core::H256;
+use sp_runtime::{traits::{BlakeTwo256, IdentityLookup}, testing::Header};
+use sp_io;
+use frame_system::EnsureSignedBy;
+use crate as doas;
+
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type Block = frame_system::mocking::MockBlock<Test>;
+
+// Logger module to track execution.
+pub mod logger {
+	use super::*;
+	use frame_system::{ensure_root, ensure_signed};
+
+	pub trait Config: frame_system::Config {
+		type Event: From<Event<Self>> + Into<<Self as frame_system::Config>::Event>;
+	}
+
+	frame_support::decl_storage! {
+		trait Store for Module<T: Config> as Logger {
+			AccountLog get(fn account_log): Vec<T::AccountId>;
+			I32Log get(fn i32_log): Vec<i32>;
+		}
+	}
+
+	frame_support::decl_event! {
+		pub enum Event<T> where AccountId = <T as frame_system::Config>::AccountId {
+			AppendI32(i32, Weight),
+			AppendI32AndAccount(AccountId, i32, Weight),
+		}
+	}
+
+	frame_support::decl_module! {
+		pub struct Module<T: Config> for enum Call where origin: <T as frame_system::Config>::Origin {
+			fn deposit_event() = default;
+
+			#[weight = *weight]
+			fn privileged_i32_log(origin, i: i32, weight: Weight){
+				// Ensure that the `origin` is `Root`.
+				ensure_root(origin)?;
+				<I32Log>::append(i);
+				Self::deposit_event(RawEvent::AppendI32(i, weight));
+			}
+
+			#[weight = *weight]
+			fn non_privileged_log(origin, i: i32, weight: Weight){
+				// Ensure that the `origin` is some signed account.
+				let sender = ensure_signed(origin)?;
+				<I32Log>::append(i);
+				<AccountLog<T>>::append(sender.clone());
+				Self::deposit_event(RawEvent::AppendI32AndAccount(sender, i, weight));
+			}
+		}
+	}
+}
+
+frame_support::construct_runtime!(
+	pub enum Test where
+	Block = Block,
+	NodeBlock = Block,
+	UncheckedExtrinsic = UncheckedExtrinsic,
+	{
+		System: frame_system::{Module, Call, Config, Storage, Event<T>},
+		Doas: doas::{Module, Call, Event<T>},
+		Logger: logger::{Module, Call, Storage, Event<T>},
+	}
+);
+parameter_types! {
+	pub const BlockHashCount: u64 = 250;
+	pub const SS58Prefix: u8 = 42;
+}
+
+impl frame_system::Config for Test {
+	type BaseCallFilter = ();
+	type BlockWeights = ();
+	type BlockLength = ();
+	type DbWeight = ();
+	type Origin = Origin;
+	type Call = Call;
+	type Index = u64;
+	type BlockNumber = u64;
+	type Hash = H256;
+	type Hashing = BlakeTwo256;
+	type AccountId = u64;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type Header = Header;
+	type Event = Event;
+	type BlockHashCount = BlockHashCount;
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = ();
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
+	type SS58Prefix = SS58Prefix;
+}
+
+// Implement the logger module's `Config` on the Test runtime.
+impl logger::Config for Test {
+	type Event = Event;
+}
+
+ord_parameter_types! {
+	pub const One: u64 = 1;
+	pub const Two: u64 = 2;
+}
+
+// Implement the doas module's `Config` on the Test runtime.
+impl Config for Test {
+	type Event = Event;
+	type Call = Call;
+	type DoasOrigin = EnsureSignedBy<One, u64>;
+}
+
+// New types for dispatchable functions.
+pub type DoasCall = doas::Call<Test>;
+pub type LoggerCall = logger::Call<Test>;
+
+// Build test environment by setting the root `key` for the Genesis.
+pub fn new_test_ext() -> sp_io::TestExternalities {
+	frame_system::GenesisConfig::default().build_storage::<Test>().unwrap().into()
+}

--- a/pallets/doas/src/tests.rs
+++ b/pallets/doas/src/tests.rs
@@ -19,121 +19,118 @@
 
 use super::*;
 use crate::Event::*;
-use mock::{
-	Doas, DoasCall, Origin, Call, new_test_ext, Logger, LoggerCall, System,
-	Event as TestEvent,
-};
-use frame_support::{assert_ok, assert_noop, dispatch::DispatchError};
+use frame_support::{assert_noop, assert_ok, dispatch::DispatchError};
+use mock::{new_test_ext, Call, Doas, DoasCall, Event as TestEvent, Logger, LoggerCall, Origin, System};
 
 #[test]
 fn test_setup_works() {
-	// Environment setup, logger storage, and sudo `key` retrieval should work as expected.
-	new_test_ext().execute_with(|| {
-		assert!(Logger::i32_log().is_empty());
-		assert!(Logger::account_log().is_empty());
-	});
+    // Environment setup, logger storage, and sudo `key` retrieval should work as expected.
+    new_test_ext().execute_with(|| {
+        assert!(Logger::i32_log().is_empty());
+        assert!(Logger::account_log().is_empty());
+    });
 }
 
 #[test]
 fn doas_root_basics() {
-	// Configure a default test environment and set the root `key` to 1.
-	new_test_ext().execute_with(|| {
-		// A privileged function should work when the correct Origin SignedBy(One) is used
-		let call = Box::new(Call::Logger(LoggerCall::privileged_i32_log(42, 1_000)));
-		assert_ok!(Doas::doas_root(Origin::signed(1), call));
-		assert_eq!(Logger::i32_log(), vec![42i32]);
+    // Configure a default test environment and set the root `key` to 1.
+    new_test_ext().execute_with(|| {
+        // A privileged function should work when the correct Origin SignedBy(One) is used
+        let call = Box::new(Call::Logger(LoggerCall::privileged_i32_log(42, 1_000)));
+        assert_ok!(Doas::doas_root(Origin::signed(1), call));
+        assert_eq!(Logger::i32_log(), vec![42i32]);
 
-		// A privileged function should not work when the incorrect Origin is used
-		let call = Box::new(Call::Logger(LoggerCall::privileged_i32_log(42, 1_000)));
-		assert_noop!(Doas::doas_root(Origin::signed(2), call), DispatchError::BadOrigin);
-	});
+        // A privileged function should not work when the incorrect Origin is used
+        let call = Box::new(Call::Logger(LoggerCall::privileged_i32_log(42, 1_000)));
+        assert_noop!(Doas::doas_root(Origin::signed(2), call), DispatchError::BadOrigin);
+    });
 }
 
 #[test]
 fn doas_root_emits_events_correctly() {
-	new_test_ext().execute_with(|| {
-		// Set block number to 1 because events are not emitted on block 0.
-		System::set_block_number(1);
+    new_test_ext().execute_with(|| {
+        // Set block number to 1 because events are not emitted on block 0.
+        System::set_block_number(1);
 
-		// Should emit event to indicate success when called with the root `key` and `call` is `Ok`.
-		let call = Box::new(Call::Logger(LoggerCall::privileged_i32_log(42, 1)));
-		assert_ok!(Doas::doas_root(Origin::signed(1), call));
-		let expected_event = TestEvent::doas(DidAsRoot(Ok(())));
-		assert!(System::events().iter().any(|a| a.event == expected_event));
-	})
+        // Should emit event to indicate success when called with the root `key` and `call` is `Ok`.
+        let call = Box::new(Call::Logger(LoggerCall::privileged_i32_log(42, 1)));
+        assert_ok!(Doas::doas_root(Origin::signed(1), call));
+        let expected_event = TestEvent::doas(DidAsRoot(Ok(())));
+        assert!(System::events().iter().any(|a| a.event == expected_event));
+    })
 }
 
 #[test]
 fn doas_root_unchecked_weight_basics() {
-	new_test_ext().execute_with(|| {
-		// A privileged function should work when `sudo` is passed the root `key` as origin.
-		let call = Box::new(Call::Logger(LoggerCall::privileged_i32_log(42, 1_000)));
-		assert_ok!(Doas::doas_root_unchecked_weight(Origin::signed(1), call, 1_000));
-		assert_eq!(Logger::i32_log(), vec![42i32]);
+    new_test_ext().execute_with(|| {
+        // A privileged function should work when `sudo` is passed the root `key` as origin.
+        let call = Box::new(Call::Logger(LoggerCall::privileged_i32_log(42, 1_000)));
+        assert_ok!(Doas::doas_root_unchecked_weight(Origin::signed(1), call, 1_000));
+        assert_eq!(Logger::i32_log(), vec![42i32]);
 
-		// A privileged function should not work when called with a non-root `key`.
-		let call = Box::new(Call::Logger(LoggerCall::privileged_i32_log(42, 1_000)));
-		assert_noop!(
-			Doas::doas_root_unchecked_weight(Origin::signed(2), call, 1_000),
-			DispatchError::BadOrigin,
-		);
-		// `I32Log` is unchanged after unsuccessful call.
-		assert_eq!(Logger::i32_log(), vec![42i32]);
+        // A privileged function should not work when called with a non-root `key`.
+        let call = Box::new(Call::Logger(LoggerCall::privileged_i32_log(42, 1_000)));
+        assert_noop!(
+            Doas::doas_root_unchecked_weight(Origin::signed(2), call, 1_000),
+            DispatchError::BadOrigin,
+        );
+        // `I32Log` is unchanged after unsuccessful call.
+        assert_eq!(Logger::i32_log(), vec![42i32]);
 
-		// Controls the dispatched weight.
-		let call = Box::new(Call::Logger(LoggerCall::privileged_i32_log(42, 1)));
-		let doas_root_unchecked_weight_call = DoasCall::doas_root_unchecked_weight(call, 1_000);
-		let info = doas_root_unchecked_weight_call.get_dispatch_info();
-		assert_eq!(info.weight, 1_000);
-	});
+        // Controls the dispatched weight.
+        let call = Box::new(Call::Logger(LoggerCall::privileged_i32_log(42, 1)));
+        let doas_root_unchecked_weight_call = DoasCall::doas_root_unchecked_weight(call, 1_000);
+        let info = doas_root_unchecked_weight_call.get_dispatch_info();
+        assert_eq!(info.weight, 1_000);
+    });
 }
 
 #[test]
 fn doas_root_unchecked_weight_emits_events_correctly() {
-	new_test_ext().execute_with(|| {
-		// Set block number to 1 because events are not emitted on block 0.
-		System::set_block_number(1);
+    new_test_ext().execute_with(|| {
+        // Set block number to 1 because events are not emitted on block 0.
+        System::set_block_number(1);
 
-		// Should emit event to indicate success when called with the root `key` and `call` is `Ok`.
-		let call = Box::new(Call::Logger(LoggerCall::privileged_i32_log(42, 1)));
-		assert_ok!(Doas::doas_root_unchecked_weight(Origin::signed(1), call, 1_000));
-		let expected_event = TestEvent::doas(DidAsRoot(Ok(())));
-		assert!(System::events().iter().any(|a| a.event == expected_event));
-	})
+        // Should emit event to indicate success when called with the root `key` and `call` is `Ok`.
+        let call = Box::new(Call::Logger(LoggerCall::privileged_i32_log(42, 1)));
+        assert_ok!(Doas::doas_root_unchecked_weight(Origin::signed(1), call, 1_000));
+        let expected_event = TestEvent::doas(DidAsRoot(Ok(())));
+        assert!(System::events().iter().any(|a| a.event == expected_event));
+    })
 }
 
 #[test]
 fn doas_basics() {
-	new_test_ext().execute_with(|| {
-		// A privileged function will not work when passed to `sudo_as`.
-		let call = Box::new(Call::Logger(LoggerCall::privileged_i32_log(42, 1_000)));
-		assert_ok!(Doas::doas(Origin::signed(1), 2, call));
-		assert!(Logger::i32_log().is_empty());
-		assert!(Logger::account_log().is_empty());
+    new_test_ext().execute_with(|| {
+        // A privileged function will not work when passed to `sudo_as`.
+        let call = Box::new(Call::Logger(LoggerCall::privileged_i32_log(42, 1_000)));
+        assert_ok!(Doas::doas(Origin::signed(1), 2, call));
+        assert!(Logger::i32_log().is_empty());
+        assert!(Logger::account_log().is_empty());
 
-		// A non-privileged function should not work when called with a non-root `key`.
-		let call = Box::new(Call::Logger(LoggerCall::non_privileged_log(42, 1)));
-		assert_noop!(Doas::doas(Origin::signed(3), 2, call), DispatchError::BadOrigin);
+        // A non-privileged function should not work when called with a non-root `key`.
+        let call = Box::new(Call::Logger(LoggerCall::non_privileged_log(42, 1)));
+        assert_noop!(Doas::doas(Origin::signed(3), 2, call), DispatchError::BadOrigin);
 
-		// A non-privileged function will work when passed to `sudo_as` with the root `key`.
-		let call = Box::new(Call::Logger(LoggerCall::non_privileged_log(42, 1)));
-		assert_ok!(Doas::doas(Origin::signed(1), 2, call));
-		assert_eq!(Logger::i32_log(), vec![42i32]);
-		 // The correct user makes the call within `sudo_as`.
-		assert_eq!(Logger::account_log(), vec![2]);
-	});
+        // A non-privileged function will work when passed to `sudo_as` with the root `key`.
+        let call = Box::new(Call::Logger(LoggerCall::non_privileged_log(42, 1)));
+        assert_ok!(Doas::doas(Origin::signed(1), 2, call));
+        assert_eq!(Logger::i32_log(), vec![42i32]);
+        // The correct user makes the call within `sudo_as`.
+        assert_eq!(Logger::account_log(), vec![2]);
+    });
 }
 
 #[test]
 fn doas_emits_events_correctly() {
-		new_test_ext().execute_with(|| {
-		// Set block number to 1 because events are not emitted on block 0.
-		System::set_block_number(1);
+    new_test_ext().execute_with(|| {
+        // Set block number to 1 because events are not emitted on block 0.
+        System::set_block_number(1);
 
-		// A non-privileged function will work when passed to `sudo_as` with the root `key`.
-		let call = Box::new(Call::Logger(LoggerCall::non_privileged_log(42, 1)));
-		assert_ok!(Doas::doas(Origin::signed(1), 2, call));
-		let expected_event = TestEvent::doas(DidAs(Ok(())));
-		assert!(System::events().iter().any(|a| a.event == expected_event));
-	});
+        // A non-privileged function will work when passed to `sudo_as` with the root `key`.
+        let call = Box::new(Call::Logger(LoggerCall::non_privileged_log(42, 1)));
+        assert_ok!(Doas::doas(Origin::signed(1), 2, call));
+        let expected_event = TestEvent::doas(DidAs(Ok(())));
+        assert!(System::events().iter().any(|a| a.event == expected_event));
+    });
 }

--- a/pallets/doas/src/tests.rs
+++ b/pallets/doas/src/tests.rs
@@ -1,0 +1,139 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2020-2021 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Tests for the module.
+
+use super::*;
+use crate::Event::*;
+use mock::{
+	Doas, DoasCall, Origin, Call, new_test_ext, Logger, LoggerCall, System,
+	Event as TestEvent,
+};
+use frame_support::{assert_ok, assert_noop, dispatch::DispatchError};
+
+#[test]
+fn test_setup_works() {
+	// Environment setup, logger storage, and sudo `key` retrieval should work as expected.
+	new_test_ext().execute_with(|| {
+		assert!(Logger::i32_log().is_empty());
+		assert!(Logger::account_log().is_empty());
+	});
+}
+
+#[test]
+fn doas_root_basics() {
+	// Configure a default test environment and set the root `key` to 1.
+	new_test_ext().execute_with(|| {
+		// A privileged function should work when the correct Origin SignedBy(One) is used
+		let call = Box::new(Call::Logger(LoggerCall::privileged_i32_log(42, 1_000)));
+		assert_ok!(Doas::doas_root(Origin::signed(1), call));
+		assert_eq!(Logger::i32_log(), vec![42i32]);
+
+		// A privileged function should not work when the incorrect Origin is used
+		let call = Box::new(Call::Logger(LoggerCall::privileged_i32_log(42, 1_000)));
+		assert_noop!(Doas::doas_root(Origin::signed(2), call), DispatchError::BadOrigin);
+	});
+}
+
+#[test]
+fn doas_root_emits_events_correctly() {
+	new_test_ext().execute_with(|| {
+		// Set block number to 1 because events are not emitted on block 0.
+		System::set_block_number(1);
+
+		// Should emit event to indicate success when called with the root `key` and `call` is `Ok`.
+		let call = Box::new(Call::Logger(LoggerCall::privileged_i32_log(42, 1)));
+		assert_ok!(Doas::doas_root(Origin::signed(1), call));
+		let expected_event = TestEvent::doas(DidAsRoot(Ok(())));
+		assert!(System::events().iter().any(|a| a.event == expected_event));
+	})
+}
+
+#[test]
+fn doas_root_unchecked_weight_basics() {
+	new_test_ext().execute_with(|| {
+		// A privileged function should work when `sudo` is passed the root `key` as origin.
+		let call = Box::new(Call::Logger(LoggerCall::privileged_i32_log(42, 1_000)));
+		assert_ok!(Doas::doas_root_unchecked_weight(Origin::signed(1), call, 1_000));
+		assert_eq!(Logger::i32_log(), vec![42i32]);
+
+		// A privileged function should not work when called with a non-root `key`.
+		let call = Box::new(Call::Logger(LoggerCall::privileged_i32_log(42, 1_000)));
+		assert_noop!(
+			Doas::doas_root_unchecked_weight(Origin::signed(2), call, 1_000),
+			DispatchError::BadOrigin,
+		);
+		// `I32Log` is unchanged after unsuccessful call.
+		assert_eq!(Logger::i32_log(), vec![42i32]);
+
+		// Controls the dispatched weight.
+		let call = Box::new(Call::Logger(LoggerCall::privileged_i32_log(42, 1)));
+		let doas_root_unchecked_weight_call = DoasCall::doas_root_unchecked_weight(call, 1_000);
+		let info = doas_root_unchecked_weight_call.get_dispatch_info();
+		assert_eq!(info.weight, 1_000);
+	});
+}
+
+#[test]
+fn doas_root_unchecked_weight_emits_events_correctly() {
+	new_test_ext().execute_with(|| {
+		// Set block number to 1 because events are not emitted on block 0.
+		System::set_block_number(1);
+
+		// Should emit event to indicate success when called with the root `key` and `call` is `Ok`.
+		let call = Box::new(Call::Logger(LoggerCall::privileged_i32_log(42, 1)));
+		assert_ok!(Doas::doas_root_unchecked_weight(Origin::signed(1), call, 1_000));
+		let expected_event = TestEvent::doas(DidAsRoot(Ok(())));
+		assert!(System::events().iter().any(|a| a.event == expected_event));
+	})
+}
+
+#[test]
+fn doas_basics() {
+	new_test_ext().execute_with(|| {
+		// A privileged function will not work when passed to `sudo_as`.
+		let call = Box::new(Call::Logger(LoggerCall::privileged_i32_log(42, 1_000)));
+		assert_ok!(Doas::doas(Origin::signed(1), 2, call));
+		assert!(Logger::i32_log().is_empty());
+		assert!(Logger::account_log().is_empty());
+
+		// A non-privileged function should not work when called with a non-root `key`.
+		let call = Box::new(Call::Logger(LoggerCall::non_privileged_log(42, 1)));
+		assert_noop!(Doas::doas(Origin::signed(3), 2, call), DispatchError::BadOrigin);
+
+		// A non-privileged function will work when passed to `sudo_as` with the root `key`.
+		let call = Box::new(Call::Logger(LoggerCall::non_privileged_log(42, 1)));
+		assert_ok!(Doas::doas(Origin::signed(1), 2, call));
+		assert_eq!(Logger::i32_log(), vec![42i32]);
+		 // The correct user makes the call within `sudo_as`.
+		assert_eq!(Logger::account_log(), vec![2]);
+	});
+}
+
+#[test]
+fn doas_emits_events_correctly() {
+		new_test_ext().execute_with(|| {
+		// Set block number to 1 because events are not emitted on block 0.
+		System::set_block_number(1);
+
+		// A non-privileged function will work when passed to `sudo_as` with the root `key`.
+		let call = Box::new(Call::Logger(LoggerCall::non_privileged_log(42, 1)));
+		assert_ok!(Doas::doas(Origin::signed(1), 2, call));
+		let expected_event = TestEvent::doas(DidAs(Ok(())));
+		assert!(System::events().iter().any(|a| a.event == expected_event));
+	});
+}

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -4,7 +4,7 @@ edition = '2018'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/dscp-node/'
 name = 'dscp-node-runtime'
-version = '3.6.0'
+version = '3.7.0'
 
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']
@@ -36,6 +36,7 @@ frame-system-benchmarking = { default-features = false, optional = true, version
 frame-system-rpc-runtime-api = { default-features = false, version = '3.0.0' }
 pallet-aura = { default-features = false, version = '3.0.0' }
 pallet-balances = { default-features = false, version = '3.0.0' }
+pallet-collective = { default-features = false, version = '3.0.0' }
 pallet-grandpa = { default-features = false, version = '3.0.0' }
 pallet-membership = { default-features = false, version = '3.0.0' }
 pallet-node-authorization = { default-features = false, version = '3.0.0' }
@@ -83,9 +84,11 @@ std = [
     'frame-system-rpc-runtime-api/std',
     'pallet-aura/std',
     'pallet-balances/std',
+    'pallet-collective/std',
     'pallet-grandpa/std',
     'pallet-membership/std',
     'pallet-node-authorization/std',
+    'pallet-process-validation/std',
     'pallet-randomness-collective-flip/std',
     'pallet-sudo/std',
     'pallet-timestamp/std',

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -25,6 +25,7 @@ hex-literal = { optional = true, version = '0.3.1' }
 serde = { features = ['derive'], optional = true, version = '1.0.101' }
 
 # local dependencies
+pallet-doas = { version = '1.0.0', default-features = false, package = 'pallet-doas', path = '../pallets/doas' }
 pallet-simple-nft = { version = '3.0.1', default-features = false, package = 'pallet-simple-nft', path = '../pallets/simple-nft' }
 pallet-process-validation = { version = '2.6.0', default-features = false, package = 'pallet-process-validation', path = '../pallets/process-validation' }
 pallet-symmetric-key = { version = '1.0.2', default-features = false, package = 'pallet-symmetric-key', path = '../pallets/symmetric-key' }
@@ -85,6 +86,7 @@ std = [
     'pallet-aura/std',
     'pallet-balances/std',
     'pallet-collective/std',
+    'pallet-doas/std',
     'pallet-grandpa/std',
     'pallet-membership/std',
     'pallet-node-authorization/std',

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -7,12 +7,16 @@
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 use codec::{Decode, Encode};
-use frame_system::{EnsureRoot, EnsureOneOf};
+use frame_system::{EnsureOneOf, EnsureRoot};
 use pallet_grandpa::fg_primitives;
 use pallet_grandpa::{AuthorityId as GrandpaId, AuthorityList as GrandpaAuthorityList};
 use sp_api::impl_runtime_apis;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
-use sp_core::{crypto::KeyTypeId, OpaqueMetadata, u32_trait::{_1, _2}};
+use sp_core::{
+    crypto::KeyTypeId,
+    u32_trait::{_1, _2},
+    OpaqueMetadata
+};
 use sp_runtime::traits::{AccountIdLookup, BlakeTwo256, Block as BlockT, IdentifyAccount, NumberFor, Verify};
 use sp_runtime::{
     create_runtime_str, generic, impl_opaque_keys,
@@ -129,13 +133,13 @@ const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
 type MoreThanHalfMembers = EnsureOneOf<
     AccountId,
     EnsureRoot<AccountId>,
-    pallet_collective::EnsureProportionMoreThan<_1, _2, AccountId, GovernanceCollective>,
+    pallet_collective::EnsureProportionMoreThan<_1, _2, AccountId, GovernanceCollective>
 >;
 
 type MoreThanTwoMembers = EnsureOneOf<
     AccountId,
     EnsureRoot<AccountId>,
-    pallet_collective::EnsureMembers<_2, AccountId, GovernanceCollective>,
+    pallet_collective::EnsureMembers<_2, AccountId, GovernanceCollective>
 >;
 
 parameter_types! {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -132,6 +132,12 @@ type MoreThanHalfMembers = EnsureOneOf<
     pallet_collective::EnsureProportionMoreThan<_1, _2, AccountId, GovernanceCollective>,
 >;
 
+type MoreThanTwoMembers = EnsureOneOf<
+    AccountId,
+    EnsureRoot<AccountId>,
+    pallet_collective::EnsureMembers<_2, AccountId, GovernanceCollective>,
+>;
+
 parameter_types! {
     pub const Version: RuntimeVersion = VERSION;
     pub const BlockHashCount: BlockNumber = 2400;
@@ -366,8 +372,8 @@ impl pallet_process_validation::Config for Runtime {
     type Event = Event;
     type ProcessIdentifier = ProcessIdentifier;
     type ProcessVersion = ProcessVersion;
-    type CreateProcessOrigin = MoreThanHalfMembers;
-    type DisableProcessOrigin = MoreThanHalfMembers;
+    type CreateProcessOrigin = MoreThanTwoMembers;
+    type DisableProcessOrigin = MoreThanTwoMembers;
     type WeightInfo = pallet_process_validation::weights::SubstrateWeight<Runtime>;
     type RoleKey = Role;
     type TokenMetadataKey = TokenMetadataKey;
@@ -417,7 +423,7 @@ impl pallet_symmetric_key::Config for Runtime {
     type RefreshPeriod = RefreshPeriod;
     type ScheduleCall = Call;
     type UpdateOrigin = MoreThanHalfMembers;
-    type RotateOrigin = MoreThanHalfMembers;
+    type RotateOrigin = MoreThanTwoMembers;
     type Randomness = RandomnessCollectiveFlip;
     type PalletsOrigin = OriginCaller;
     type Scheduler = Scheduler;


### PR DESCRIPTION
Adds voting support to the runtime. The thresholds for voting are somewhat arbtrary at the moment by highlight the art of the possible. Notably:

1. Root like operations require a majority of the `TechnicalCommittee`
2. Rotating the IPFS key should always be safe so only requires 2 members of the `TechnicalCommittee`
3. Process flow changes are safe so only require 2 members of the `TechnicalCommittee`

`Sudo` is still present and can do everything as before

### Implementation notes

The `pallet-collective` only allows us to generate new `Origin`s that can be used when restricting call permissions. In order to perform opperations that would usually require `Root` permissions (such as `system::set_code` we need a way of enabling the collective to perform `Root` operations. The way I've done this is by implementing a new pallet `pallet-doas` (named for the sudo alternative [doas](https://man.openbsd.org/doas)). This allows us to configure an Origin in the runtime that will be able to act like `Root`. We then configure that Origin to be sourced from the `TechnicalCommittee` implemented using `pallet-collective`