### PR TITLE
Bug/transaction payment naming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1263,7 +1263,7 @@ dependencies = [
 
 [[package]]
 name = "dscp-node"
-version = "3.7.0"
+version = "3.8.0"
 dependencies = [
  "bs58",
  "dscp-node-runtime",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -6,7 +6,7 @@ edition = '2018'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/dscp-node/'
 name = 'dscp-node'
-version = '3.7.0'
+version = '3.8.0'
 
 [[bin]]
 name = 'dscp-node'

--- a/pallets/transaction-payment-free/src/lib.rs
+++ b/pallets/transaction-payment-free/src/lib.rs
@@ -34,9 +34,9 @@ decl_module! {
 
 /// Require the transactor have balance. All transactions are free - they have no fee
 #[derive(Encode, Decode, Clone, Eq, PartialEq)]
-pub struct OnChargeTransaction<T: Config>(#[codec(compact)] BalanceOf<T>);
+pub struct ChargeTransactionPayment<T: Config>(#[codec(compact)] BalanceOf<T>);
 
-impl<T: Config> OnChargeTransaction<T>
+impl<T: Config> ChargeTransactionPayment<T>
 where
     T::Call: Dispatchable<Info = DispatchInfo, PostInfo = PostDispatchInfo>,
     BalanceOf<T>: Send + Sync + FixedPointOperand
@@ -70,10 +70,10 @@ where
     }
 }
 
-impl<T: Config> sp_std::fmt::Debug for OnChargeTransaction<T> {
+impl<T: Config> sp_std::fmt::Debug for ChargeTransactionPayment<T> {
     #[cfg(feature = "std")]
     fn fmt(&self, f: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
-        write!(f, "OnChargeTransaction<{:?}>", self.0)
+        write!(f, "ChargeTransactionPayment<{:?}>", self.0)
     }
     #[cfg(not(feature = "std"))]
     fn fmt(&self, _: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
@@ -81,12 +81,12 @@ impl<T: Config> sp_std::fmt::Debug for OnChargeTransaction<T> {
     }
 }
 
-impl<T: Config> SignedExtension for OnChargeTransaction<T>
+impl<T: Config> SignedExtension for ChargeTransactionPayment<T>
 where
     BalanceOf<T>: Send + Sync + From<u64> + FixedPointOperand,
     T::Call: Dispatchable<Info = DispatchInfo, PostInfo = PostDispatchInfo>
 {
-    const IDENTIFIER: &'static str = "OnChargeTransaction";
+    const IDENTIFIER: &'static str = "ChargeTransactionPayment";
     type AccountId = T::AccountId;
     type Call = T::Call;
     type AdditionalSigned = ();

--- a/pallets/transaction-payment-free/src/tests.rs
+++ b/pallets/transaction-payment-free/src/tests.rs
@@ -8,7 +8,7 @@ fn transaction_payment_works_with_no_fee_for_account_with_balance() {
     new_test_ext().execute_with(|| {
         let user = 1;
         assert_eq!(Balances::free_balance(user), 10);
-        assert_ok!(OnChargeTransaction::<Test>::from(0).pre_dispatch(&user, CALL, &info_from_weight(0), 0));
+        assert_ok!(ChargeTransactionPayment::<Test>::from(0).pre_dispatch(&user, CALL, &info_from_weight(0), 0));
         assert_eq!(Balances::free_balance(user), 10);
     });
 }
@@ -22,7 +22,7 @@ fn transaction_payment_fails_for_account_with_no_balance() {
         let user = 2;
         assert_eq!(Balances::free_balance(user), 0);
         assert_err!(
-            OnChargeTransaction::<Test>::from(0).pre_dispatch(&user, CALL, &info_from_weight(0), 0),
+            ChargeTransactionPayment::<Test>::from(0).pre_dispatch(&user, CALL, &info_from_weight(0), 0),
             InvalidTransaction::Payment
         );
         // No events for such a scenario

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -471,7 +471,7 @@ pub type SignedExtra = (
     frame_system::CheckEra<Runtime>,
     frame_system::CheckNonce<Runtime>,
     frame_system::CheckWeight<Runtime>,
-    pallet_transaction_payment_free::OnChargeTransaction<Runtime>
+    pallet_transaction_payment_free::ChargeTransactionPayment<Runtime>
 );
 /// Unchecked extrinsic type as expected by this runtime.
 pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<Address, Call, Signature, SignedExtra>;


### PR DESCRIPTION
When refactoring https://github.com/digicatapult/dscp-node/pull/68 I confused `OnChargeTransaction` with `ChargeTransactionPayment` and didn't notice because the node was still building/tests were passing. This corrects some of the renames. 

I also missed bumping the node version so this does that too.