### PR TITLE
Re-enable combined restriction functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1260,7 +1260,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "dscp-node"
-version = "4.3.2"
+version = "4.3.0"
 dependencies = [
  "bs58",
  "clap",
@@ -1302,7 +1302,7 @@ dependencies = [
 
 [[package]]
 name = "dscp-node-runtime"
-version = "4.3.2"
+version = "4.3.0"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1260,7 +1260,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "dscp-node"
-version = "4.2.2"
+version = "4.3.2"
 dependencies = [
  "bs58",
  "clap",
@@ -1302,7 +1302,7 @@ dependencies = [
 
 [[package]]
 name = "dscp-node-runtime"
-version = "4.2.2"
+version = "4.3.2"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",
@@ -4194,7 +4194,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-process-validation"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "dscp-pallet-traits",
  "frame-benchmarking",

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-node",
-  "version": "4.3.2",
+  "version": "4.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-node",
-      "version": "4.3.2",
+      "version": "4.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^8.11.3"

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-node",
-  "version": "4.2.2",
+  "version": "4.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-node",
-      "version": "4.2.2",
+      "version": "4.3.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^8.11.3"

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-node",
-  "version": "4.2.2",
+  "version": "4.3.2",
   "description": "DSCP node types",
   "repository": {
     "type": "git",

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-node",
-  "version": "4.3.2",
+  "version": "4.3.0",
   "description": "DSCP node types",
   "repository": {
     "type": "git",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -6,7 +6,7 @@ edition = '2021'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/dscp-node/'
 name = 'dscp-node'
-version = '4.3.2'
+version = '4.3.0'
 
 [[bin]]
 name = 'dscp-node'
@@ -55,7 +55,7 @@ frame-benchmarking = { version = "4.0.0-dev", git = "https://github.com/parityte
 frame-benchmarking-cli = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25" }
 
 # Local Dependencies
-dscp-node-runtime = { path = '../runtime', version = '4.3.2' }
+dscp-node-runtime = { path = '../runtime', version = '4.3.0' }
 
 # CLI-specific dependencies
 try-runtime-cli = { version = "0.10.0-dev", optional = true, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25" }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -6,7 +6,7 @@ edition = '2021'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/dscp-node/'
 name = 'dscp-node'
-version = '4.2.2'
+version = '4.3.2'
 
 [[bin]]
 name = 'dscp-node'
@@ -55,7 +55,7 @@ frame-benchmarking = { version = "4.0.0-dev", git = "https://github.com/parityte
 frame-benchmarking-cli = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25" }
 
 # Local Dependencies
-dscp-node-runtime = { path = '../runtime', version = '4.2.2' }
+dscp-node-runtime = { path = '../runtime', version = '4.3.2' }
 
 # CLI-specific dependencies
 try-runtime-cli = { version = "0.10.0-dev", optional = true, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25" }

--- a/pallets/process-validation/Cargo.toml
+++ b/pallets/process-validation/Cargo.toml
@@ -5,7 +5,7 @@ edition = '2021'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/dscp-node/'
 name = 'pallet-process-validation'
-version = "3.0.0"
+version = "3.1.0"
 
 
 [package.metadata.docs.rs]

--- a/pallets/process-validation/src/binary_expression_tree.rs
+++ b/pallets/process-validation/src/binary_expression_tree.rs
@@ -6,50 +6,62 @@ use crate::Restriction;
 #[derive(Encode, Decode, Clone, MaxEncodedLen, TypeInfo, PartialEq)]
 #[cfg_attr(feature = "std", derive(Debug))]
 pub enum BooleanOperator {
-  Null, // false
-  Identity, // true
-  TransferL, // A
-  TransferR, // B
-  NotL, // !A
-  NotR, // !B
-  And, // A and B
-  Nand, // !(A and B)
-  Or, // A or B
-  Nor, // !(A or B)
-  Xor, // (A and !B) or (!A and B)
-  Xnor, // A equals B
-  ImplicationL, // if(A) then B else true
-  ImplicationR, // if(B) then A else true
-  InhibitionL, // A and !B
-  InhibitionR // B and !A
+    Null,         // false
+    Identity,     // true
+    TransferL,    // A
+    TransferR,    // B
+    NotL,         // !A
+    NotR,         // !B
+    And,          // A and B
+    Nand,         // !(A and B)
+    Or,           // A or B
+    Nor,          // !(A or B)
+    Xor,          // (A and !B) or (!A and B)
+    Xnor,         // A equals B
+    ImplicationL, // if(A) then B else true
+    ImplicationR, // if(B) then A else true
+    InhibitionL,  // A and !B
+    InhibitionR   // B and !A
 }
 
 #[derive(Encode, Decode, Clone, MaxEncodedLen, TypeInfo, PartialEq)]
 #[cfg_attr(feature = "std", derive(Debug))]
 pub enum BooleanExpressionSymbol<RoleKey, TokenMetadataKey, TokenMetadataValue, TokenMetadataValueDiscriminator> {
-  Op(BooleanOperator),
-  Restriction(Restriction<RoleKey, TokenMetadataKey, TokenMetadataValue, TokenMetadataValueDiscriminator>)
+    Op(BooleanOperator),
+    Restriction(Restriction<RoleKey, TokenMetadataKey, TokenMetadataValue, TokenMetadataValueDiscriminator>)
 }
 
 impl BooleanOperator {
-  pub fn eval(&self, a: bool, b: bool) -> bool {
-    match self {
-      Self::Identity => true,
-      Self::Null => false,
-      Self::TransferL => a,
-      Self::TransferR => b,
-      Self::NotL => !a,
-      Self::NotR => !b,
-      Self::And => a & b,
-      Self::Nand => !(a & b),
-      Self::Or => a | b,
-      Self::Nor => !(a | b),
-      Self::Xor => a ^ b,
-      Self::Xnor => a == b,
-      Self::ImplicationL => if a { b } else { true },
-      Self::ImplicationR => if b { a } else { true },
-      Self::InhibitionL => a & !b,
-      Self::InhibitionR => b & !a,
+    pub fn eval(&self, a: bool, b: bool) -> bool {
+        match self {
+            Self::Identity => true,
+            Self::Null => false,
+            Self::TransferL => a,
+            Self::TransferR => b,
+            Self::NotL => !a,
+            Self::NotR => !b,
+            Self::And => a & b,
+            Self::Nand => !(a & b),
+            Self::Or => a | b,
+            Self::Nor => !(a | b),
+            Self::Xor => a ^ b,
+            Self::Xnor => a == b,
+            Self::ImplicationL => {
+                if a {
+                    b
+                } else {
+                    true
+                }
+            }
+            Self::ImplicationR => {
+                if b {
+                    a
+                } else {
+                    true
+                }
+            }
+            Self::InhibitionL => a & !b,
+            Self::InhibitionR => b & !a
+        }
     }
-  }
 }

--- a/pallets/process-validation/src/binary_expression_tree.rs
+++ b/pallets/process-validation/src/binary_expression_tree.rs
@@ -1,0 +1,55 @@
+use codec::{Decode, Encode, MaxEncodedLen};
+use scale_info::TypeInfo;
+
+use crate::Restriction;
+
+#[derive(Encode, Decode, Clone, MaxEncodedLen, TypeInfo, PartialEq)]
+#[cfg_attr(feature = "std", derive(Debug))]
+pub enum BooleanOperator {
+  Null, // false
+  Identity, // true
+  TransferL, // A
+  TransferR, // B
+  NotL, // !A
+  NotR, // !B
+  And, // A and B
+  Nand, // !(A and B)
+  Or, // A or B
+  Nor, // !(A or B)
+  Xor, // (A and !B) or (!A and B)
+  Xnor, // A equals B
+  ImplicationL, // if(A) then B else true
+  ImplicationR, // if(B) then A else true
+  InhibitionL, // A and !B
+  InhibitionR // B and !A
+}
+
+#[derive(Encode, Decode, Clone, MaxEncodedLen, TypeInfo, PartialEq)]
+#[cfg_attr(feature = "std", derive(Debug))]
+pub enum BooleanExpressionSymbol<RoleKey, TokenMetadataKey, TokenMetadataValue, TokenMetadataValueDiscriminator> {
+  Op(BooleanOperator),
+  Restriction(Restriction<RoleKey, TokenMetadataKey, TokenMetadataValue, TokenMetadataValueDiscriminator>)
+}
+
+impl BooleanOperator {
+  pub fn eval(&self, a: bool, b: bool) -> bool {
+    match self {
+      Self::Identity => true,
+      Self::Null => false,
+      Self::TransferL => a,
+      Self::TransferR => b,
+      Self::NotL => !a,
+      Self::NotR => !b,
+      Self::And => a & b,
+      Self::Nand => !(a & b),
+      Self::Or => a | b,
+      Self::Nor => !(a | b),
+      Self::Xor => a ^ b,
+      Self::Xnor => a == b,
+      Self::ImplicationL => if a { b } else { true },
+      Self::ImplicationR => if b { a } else { true },
+      Self::InhibitionL => a & !b,
+      Self::InhibitionR => b & !a,
+    }
+  }
+}

--- a/pallets/process-validation/src/tests.rs
+++ b/pallets/process-validation/src/tests.rs
@@ -4,7 +4,7 @@ use crate as pallet_process_validation;
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{
     parameter_types,
-    traits::{ConstU32, ConstU64, ConstU8}
+    traits::{ConstU32, ConstU64}
 };
 use frame_system as system;
 use scale_info::TypeInfo;
@@ -103,8 +103,7 @@ impl pallet_process_validation::Config for Test {
     type TokenMetadataValue = u128;
     type TokenMetadataValueDiscriminator = TokenMetadataValueDiscriminator;
 
-    type MaxRestrictionDepth = ConstU8<2>;
-    type MaxProcessRestrictions = ConstU32<32>;
+    type MaxProcessProgramLength = ConstU32<8>;
 }
 
 // This function basically just builds a genesis storage key/value store according to

--- a/pallets/process-validation/src/tests/create_process.rs
+++ b/pallets/process-validation/src/tests/create_process.rs
@@ -1,19 +1,14 @@
 use super::*;
+use crate::binary_expression_tree::BooleanExpressionSymbol;
+use crate::binary_expression_tree::BooleanOperator;
 use crate::tests::Event as TestEvent;
 use crate::tests::ProcessIdentifier;
 use crate::Error;
 use crate::Event::*;
-use crate::{
-    Process,
-    ProcessModel,
-    ProcessStatus,
-    // Restriction::Combined, BinaryOperator,
-    Restriction::None,
-    VersionModel
-};
+use crate::{Process, ProcessModel, ProcessStatus, Restriction::None, VersionModel};
 use frame_support::bounded_vec;
 use frame_support::{assert_noop, assert_ok, dispatch::DispatchError};
-// use sp_runtime::ModuleError;
+use sp_runtime::ModuleError;
 
 // -- fixtures --
 #[allow(dead_code)]
@@ -25,17 +20,15 @@ fn returns_error_if_origin_validation_fails_and_no_data_added() {
     new_test_ext().execute_with(|| {
         System::set_block_number(1);
         assert_noop!(
-            ProcessValidation::create_process(Origin::none(), PROCESS_ID1, bounded_vec![{ None }]),
+            ProcessValidation::create_process(
+                Origin::none(),
+                PROCESS_ID1,
+                bounded_vec![BooleanExpressionSymbol::Restriction(None)]
+            ),
             DispatchError::BadOrigin,
         );
         assert_eq!(<VersionModel<Test>>::get(PROCESS_ID1), 0u32);
-        assert_eq!(
-            <ProcessModel<Test>>::get(PROCESS_ID1, 1u32),
-            Process {
-                status: ProcessStatus::Disabled,
-                restrictions: bounded_vec![]
-            }
-        );
+        assert_eq!(<ProcessModel<Test>>::get(PROCESS_ID1, 1u32), Default::default());
         assert_eq!(System::events().len(), 0);
     });
 }
@@ -48,10 +41,14 @@ fn handles_if_process_exists_for_the_new_version() {
             1,
             Process {
                 status: ProcessStatus::Disabled,
-                restrictions: bounded_vec![{ None }]
+                program: bounded_vec![BooleanExpressionSymbol::Restriction(None)]
             }
         );
-        let result = ProcessValidation::create_process(Origin::root(), PROCESS_ID1, bounded_vec![{ None }]);
+        let result = ProcessValidation::create_process(
+            Origin::root(),
+            PROCESS_ID1,
+            bounded_vec![BooleanExpressionSymbol::Restriction(None)]
+        );
         assert_noop!(result, Error::<Test>::AlreadyExists);
     });
 }
@@ -64,16 +61,33 @@ fn if_no_version_found_it_should_return_default_and_insert_new_one() {
         assert_ok!(ProcessValidation::create_process(
             Origin::root(),
             PROCESS_ID1,
-            bounded_vec![{ None }],
+            bounded_vec![
+                BooleanExpressionSymbol::Restriction(None),
+                BooleanExpressionSymbol::Restriction(None),
+                BooleanExpressionSymbol::Op(BooleanOperator::And)
+            ]
         ));
 
-        let expected = TestEvent::ProcessValidation(ProcessCreated(PROCESS_ID1, 1u32, bounded_vec![{ None }], true));
+        let expected = TestEvent::ProcessValidation(ProcessCreated(
+            PROCESS_ID1,
+            1u32,
+            bounded_vec![
+                BooleanExpressionSymbol::Restriction(None),
+                BooleanExpressionSymbol::Restriction(None),
+                BooleanExpressionSymbol::Op(BooleanOperator::And)
+            ],
+            true
+        ));
         assert_eq!(System::events()[0].event, expected);
         assert_eq!(
             <ProcessModel<Test>>::get(PROCESS_ID1, 1u32),
             Process {
                 status: ProcessStatus::Enabled,
-                restrictions: bounded_vec![{ None }]
+                program: bounded_vec![
+                    BooleanExpressionSymbol::Restriction(None),
+                    BooleanExpressionSymbol::Restriction(None),
+                    BooleanExpressionSymbol::Op(BooleanOperator::And)
+                ]
             }
         );
     });
@@ -105,19 +119,27 @@ fn sets_versions_correctly_for_multiple_processes() {
             assert_ok!(ProcessValidation::update_version(id.clone()));
         });
 
-        let id1_expected =
-            TestEvent::ProcessValidation(ProcessCreated(PROCESS_ID1, 16u32, bounded_vec![{ None }], false));
+        let id1_expected = TestEvent::ProcessValidation(ProcessCreated(
+            PROCESS_ID1,
+            16u32,
+            bounded_vec![BooleanExpressionSymbol::Restriction(None)],
+            false
+        ));
         assert_ok!(ProcessValidation::create_process(
             Origin::root(),
             PROCESS_ID1,
-            bounded_vec![{ None }],
+            bounded_vec![BooleanExpressionSymbol::Restriction(None)],
         ));
-        let id2_expected =
-            TestEvent::ProcessValidation(ProcessCreated(PROCESS_ID2, 11u32, bounded_vec![{ None }], false));
+        let id2_expected = TestEvent::ProcessValidation(ProcessCreated(
+            PROCESS_ID2,
+            11u32,
+            bounded_vec![BooleanExpressionSymbol::Restriction(None)],
+            false
+        ));
         assert_ok!(ProcessValidation::create_process(
             Origin::root(),
             PROCESS_ID2,
-            bounded_vec![{ None }],
+            bounded_vec![BooleanExpressionSymbol::Restriction(None)],
         ));
 
         assert_eq!(System::events()[0].event, id1_expected);
@@ -130,11 +152,16 @@ fn updates_version_correctly_for_existing_proces_and_dispatches_event() {
     new_test_ext().execute_with(|| {
         System::set_block_number(1);
         <VersionModel<Test>>::insert(PROCESS_ID1, 9u32);
-        let expected = TestEvent::ProcessValidation(ProcessCreated(PROCESS_ID1, 10u32, bounded_vec![{ None }], false));
+        let expected = TestEvent::ProcessValidation(ProcessCreated(
+            PROCESS_ID1,
+            10u32,
+            bounded_vec![BooleanExpressionSymbol::Restriction(None)],
+            false
+        ));
         assert_ok!(ProcessValidation::create_process(
             Origin::root(),
             PROCESS_ID1,
-            bounded_vec![{ None }],
+            bounded_vec![BooleanExpressionSymbol::Restriction(None)],
         ));
         assert_eq!(<VersionModel<Test>>::get(PROCESS_ID1), 10u32);
         assert_eq!(System::events()[0].event, expected);
@@ -148,88 +175,68 @@ fn updates_version_correctly_for_new_process_and_dispatches_event() {
         assert_ok!(ProcessValidation::create_process(
             Origin::root(),
             PROCESS_ID1,
-            bounded_vec![{ None }],
+            bounded_vec![BooleanExpressionSymbol::Restriction(None)],
         ));
-        let expected = TestEvent::ProcessValidation(ProcessCreated(PROCESS_ID1, 1u32, bounded_vec![{ None }], true));
+        let expected = TestEvent::ProcessValidation(ProcessCreated(
+            PROCESS_ID1,
+            1u32,
+            bounded_vec![BooleanExpressionSymbol::Restriction(None)],
+            true
+        ));
         // sets version to 1 and returns true to identify that this is a new event
         assert_eq!(<VersionModel<Test>>::get(PROCESS_ID1), 1u32);
         assert_eq!(System::events()[0].event, expected);
     });
 }
 
-// #[test]
-// fn combined_with_depth_succeeds() {
-//     new_test_ext().execute_with(|| {
-//         System::set_block_number(1);
-//         assert_ok!(ProcessValidation::create_process(
-//             Origin::root(),
-//             PROCESS_ID1,
-//             bounded_vec![Combined {
-//                 operator: BinaryOperator::AND,
-//                 restriction_a: { Box::new(None) },
-//                 restriction_b: Box::new(Combined {
-//                     operator: BinaryOperator::AND,
-//                     restriction_a: { Box::new(None) },
-//                     restriction_b: { Box::new(None) }
-//                 })
-//             }]
-//         ));
-//         let expected = TestEvent::ProcessValidation(ProcessCreated(
-//             PROCESS_ID1,
-//             1u32,
-//             bounded_vec![Combined {
-//                 operator: BinaryOperator::AND,
-//                 restriction_a: { Box::new(None) },
-//                 restriction_b: Box::new(Combined {
-//                     operator: BinaryOperator::AND,
-//                     restriction_a: { Box::new(None) },
-//                     restriction_b: { Box::new(None) }
-//                 })
-//             }],
-//             true
-//         ));
-//         // sets version to 1 and returns true to identify that this is a new event
-//         assert_eq!(<VersionModel<Test>>::get(PROCESS_ID1), 1u32);
-//         assert_eq!(System::events()[0].event, expected);
-//     });
-// }
+#[test]
+fn program_invalid_negative_stack() {
+    new_test_ext().execute_with(|| {
+        System::set_block_number(1);
+        assert_noop!(
+            ProcessValidation::create_process(
+                Origin::root(),
+                PROCESS_ID1,
+                bounded_vec![
+                    BooleanExpressionSymbol::Restriction(None),
+                    BooleanExpressionSymbol::Op(BooleanOperator::And),
+                ]
+            ),
+            DispatchError::Module(ModuleError {
+                index: 1,
+                error: [4, 0, 0, 0],
+                message: Some("InvalidProgram")
+            }),
+        );
+        assert_eq!(<VersionModel<Test>>::get(PROCESS_ID1), 0u32);
+        assert_eq!(<ProcessModel<Test>>::get(PROCESS_ID1, 1u32), Default::default());
+        assert_eq!(System::events().len(), 0);
+    });
+}
 
-// #[test]
-// fn combined_over_max_depth_fails() {
-//     new_test_ext().execute_with(|| {
-//         System::set_block_number(1);
-//         assert_noop!(
-//             ProcessValidation::create_process(
-//                 Origin::root(),
-//                 PROCESS_ID1,
-//                 bounded_vec![Combined {
-//                     operator: BinaryOperator::AND,
-//                     restriction_a: { Box::new(None) },
-//                     restriction_b: Box::new(Combined {
-//                         operator: BinaryOperator::AND,
-//                         restriction_a: { Box::new(None) },
-//                         restriction_b: Box::new(Combined {
-//                             operator: BinaryOperator::AND,
-//                             restriction_a: { Box::new(None) },
-//                             restriction_b: { Box::new(None) }
-//                         })
-//                     })
-//                 }]
-//             ),
-//             DispatchError::Module(ModuleError {
-//                 index: 1,
-//                 error: [4, 0, 0, 0],
-//                 message: Some("RestrictionsTooDeep")
-//             }),
-//         );
-//         assert_eq!(<VersionModel<Test>>::get(PROCESS_ID1), 0u32);
-//         assert_eq!(
-//             <ProcessModel<Test>>::get(PROCESS_ID1, 1u32),
-//             Process {
-//                 status: ProcessStatus::Disabled,
-//                 restrictions: bounded_vec![]
-//             }
-//         );
-//         assert_eq!(System::events().len(), 0);
-//     });
-// }
+#[test]
+fn program_invalid_expect_single_stack() {
+    new_test_ext().execute_with(|| {
+        System::set_block_number(1);
+        assert_noop!(
+            ProcessValidation::create_process(
+                Origin::root(),
+                PROCESS_ID1,
+                bounded_vec![
+                    BooleanExpressionSymbol::Restriction(None),
+                    BooleanExpressionSymbol::Restriction(None),
+                    BooleanExpressionSymbol::Restriction(None),
+                    BooleanExpressionSymbol::Op(BooleanOperator::And),
+                ]
+            ),
+            DispatchError::Module(ModuleError {
+                index: 1,
+                error: [4, 0, 0, 0],
+                message: Some("InvalidProgram")
+            }),
+        );
+        assert_eq!(<VersionModel<Test>>::get(PROCESS_ID1), 0u32);
+        assert_eq!(<ProcessModel<Test>>::get(PROCESS_ID1, 1u32), Default::default());
+        assert_eq!(System::events().len(), 0);
+    });
+}

--- a/pallets/process-validation/src/tests/disable_process.rs
+++ b/pallets/process-validation/src/tests/disable_process.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::tests::{Event as TestEvent, ProcessIdentifier};
 use crate::Error;
 use crate::Event::*;
-use crate::{Process, ProcessModel, ProcessStatus, Restriction::None, VersionModel};
+use crate::{binary_expression_tree::*, Process, ProcessModel, ProcessStatus, Restriction::None, VersionModel};
 use frame_support::bounded_vec;
 use frame_support::{assert_noop, assert_ok, dispatch::DispatchError};
 
@@ -42,7 +42,7 @@ fn returns_error_if_process_is_already_disabled() {
             1u32,
             Process {
                 status: ProcessStatus::Disabled,
-                restrictions: bounded_vec![{ None }]
+                program: bounded_vec![BooleanExpressionSymbol::Restriction(None)]
             }
         );
         assert_noop!(
@@ -63,7 +63,7 @@ fn disables_process_and_dispatches_event() {
             1u32,
             Process {
                 status: ProcessStatus::Enabled,
-                restrictions: bounded_vec![{ None }]
+                program: bounded_vec![BooleanExpressionSymbol::Restriction(None)]
             }
         );
         assert_ok!(ProcessValidation::disable_process(Origin::root(), PROCESS_ID, 1u32,));
@@ -82,7 +82,7 @@ fn disables_process_and_dispatches_event_previous_version() {
             1u32,
             Process {
                 status: ProcessStatus::Enabled,
-                restrictions: bounded_vec![{ None }]
+                program: bounded_vec![BooleanExpressionSymbol::Restriction(None)]
             }
         );
         <ProcessModel<Test>>::insert(
@@ -90,7 +90,7 @@ fn disables_process_and_dispatches_event_previous_version() {
             2u32,
             Process {
                 status: ProcessStatus::Enabled,
-                restrictions: bounded_vec![{ None }]
+                program: bounded_vec![BooleanExpressionSymbol::Restriction(None)]
             }
         );
         assert_ok!(ProcessValidation::disable_process(Origin::root(), PROCESS_ID, 1u32,));

--- a/pallets/process-validation/src/tests/validate_process.rs
+++ b/pallets/process-validation/src/tests/validate_process.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 use dscp_pallet_traits::{ProcessFullyQualifiedId, ProcessIO, ProcessValidator};
-use frame_support::{bounded_vec};
+use frame_support::bounded_vec;
 use sp_std::collections::btree_map::BTreeMap;
 
 use crate::binary_expression_tree::{BooleanExpressionSymbol, BooleanOperator};

--- a/pallets/process-validation/src/tests/validate_process.rs
+++ b/pallets/process-validation/src/tests/validate_process.rs
@@ -1,9 +1,10 @@
 use super::*;
 
 use dscp_pallet_traits::{ProcessFullyQualifiedId, ProcessIO, ProcessValidator};
-use frame_support::bounded_vec;
+use frame_support::{bounded_vec};
 use sp_std::collections::btree_map::BTreeMap;
 
+use crate::binary_expression_tree::{BooleanExpressionSymbol, BooleanOperator};
 use crate::restrictions::Restriction;
 use crate::{Process, ProcessModel, ProcessStatus};
 
@@ -15,7 +16,7 @@ fn it_succeeds_when_process_exists() {
             1u32,
             Process {
                 status: ProcessStatus::Enabled,
-                restrictions: bounded_vec![]
+                program: bounded_vec![BooleanExpressionSymbol::Restriction(Restriction::None)]
             }
         );
 
@@ -39,7 +40,7 @@ fn it_fails_when_process_id_doesnt_exist() {
             1u32,
             Process {
                 status: ProcessStatus::Enabled,
-                restrictions: bounded_vec![]
+                program: bounded_vec![BooleanExpressionSymbol::Restriction(Restriction::None)]
             }
         );
 
@@ -63,7 +64,7 @@ fn it_fails_when_process_version_doesnt_exist() {
             1u32,
             Process {
                 status: ProcessStatus::Enabled,
-                restrictions: bounded_vec![]
+                program: bounded_vec![BooleanExpressionSymbol::Restriction(Restriction::None)]
             }
         );
 
@@ -87,7 +88,7 @@ fn it_fails_when_process_disabled() {
             1u32,
             Process {
                 status: ProcessStatus::Disabled,
-                restrictions: bounded_vec![]
+                program: bounded_vec![BooleanExpressionSymbol::Restriction(Restriction::None)]
             }
         );
 
@@ -111,7 +112,11 @@ fn it_succeeds_when_all_restrictions_succeed() {
             1u32,
             Process {
                 status: ProcessStatus::Enabled,
-                restrictions: bounded_vec![Restriction::None, Restriction::SenderOwnsAllInputs]
+                program: bounded_vec![
+                    BooleanExpressionSymbol::Restriction(Restriction::None),
+                    BooleanExpressionSymbol::Restriction(Restriction::SenderOwnsAllInputs),
+                    BooleanExpressionSymbol::Op(BooleanOperator::And)
+                ]
             }
         );
 
@@ -142,7 +147,11 @@ fn it_fails_when_one_restrictions_fails() {
             1u32,
             Process {
                 status: ProcessStatus::Enabled,
-                restrictions: bounded_vec![Restriction::None, Restriction::SenderOwnsAllInputs]
+                program: bounded_vec![
+                    BooleanExpressionSymbol::Restriction(Restriction::None),
+                    BooleanExpressionSymbol::Restriction(Restriction::SenderOwnsAllInputs),
+                    BooleanExpressionSymbol::Op(BooleanOperator::And)
+                ]
             }
         );
 
@@ -155,6 +164,80 @@ fn it_fails_when_one_restrictions_fails() {
                 version: 1u32
             },
             &0u64,
+            &vec![ProcessIO {
+                roles: token_roles,
+                metadata: BTreeMap::new(),
+                parent_index: None
+            }],
+            &bounded_vec![],
+        ));
+    });
+}
+
+#[test]
+fn it_succeeds_wth_complex_tree() {
+    new_test_ext().execute_with(|| {
+        ProcessModel::<Test>::insert(
+            ProcessIdentifier::A,
+            1u32,
+            Process {
+                status: ProcessStatus::Enabled,
+                program: bounded_vec![
+                    BooleanExpressionSymbol::Restriction(Restriction::None),
+                    BooleanExpressionSymbol::Restriction(Restriction::Fail),
+                    BooleanExpressionSymbol::Op(BooleanOperator::Or),
+                    BooleanExpressionSymbol::Restriction(Restriction::SenderOwnsAllInputs),
+                    BooleanExpressionSymbol::Op(BooleanOperator::And)
+                ]
+            }
+        );
+
+        let mut token_roles: BTreeMap<u32, u64> = BTreeMap::new();
+        token_roles.insert(Default::default(), 1u64);
+
+        assert!(ProcessValidation::validate_process(
+            ProcessFullyQualifiedId {
+                id: ProcessIdentifier::A,
+                version: 1u32
+            },
+            &1u64,
+            &vec![ProcessIO {
+                roles: token_roles,
+                metadata: BTreeMap::new(),
+                parent_index: None
+            }],
+            &bounded_vec![],
+        ));
+    });
+}
+
+#[test]
+fn it_fails_wth_complex_tree() {
+    new_test_ext().execute_with(|| {
+        ProcessModel::<Test>::insert(
+            ProcessIdentifier::A,
+            1u32,
+            Process {
+                status: ProcessStatus::Enabled,
+                program: bounded_vec![
+                    BooleanExpressionSymbol::Restriction(Restriction::None),
+                    BooleanExpressionSymbol::Restriction(Restriction::Fail),
+                    BooleanExpressionSymbol::Op(BooleanOperator::Or),
+                    BooleanExpressionSymbol::Restriction(Restriction::SenderOwnsAllInputs),
+                    BooleanExpressionSymbol::Op(BooleanOperator::Xor)
+                ]
+            }
+        );
+
+        let mut token_roles: BTreeMap<u32, u64> = BTreeMap::new();
+        token_roles.insert(Default::default(), 1u64);
+
+        assert!(!ProcessValidation::validate_process(
+            ProcessFullyQualifiedId {
+                id: ProcessIdentifier::A,
+                version: 1u32
+            },
+            &1u64,
             &vec![ProcessIO {
                 roles: token_roles,
                 metadata: BTreeMap::new(),

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dscp-node-runtime"
-version = "4.2.2"
+version = "4.3.2"
 authors = ["Digital Catapult <https://www.digicatapult.org.uk>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -56,7 +56,7 @@ hex-literal = { version = "0.3.4", optional = true }
 # Local Dependencies
 pallet-doas = { version = '2.0.0', default-features = false, package = 'pallet-doas', path = '../pallets/doas' }
 pallet-simple-nft = { version = '4.0.0', default-features = false, package = 'pallet-simple-nft', path = '../pallets/simple-nft' }
-pallet-process-validation = { version = '3.0.0', default-features = false, package = 'pallet-process-validation', path = '../pallets/process-validation' }
+pallet-process-validation = { version = '3.1.0', default-features = false, package = 'pallet-process-validation', path = '../pallets/process-validation' }
 pallet-symmetric-key = { version = '2.0.0', default-features = false, package = 'pallet-symmetric-key', path = '../pallets/symmetric-key' }
 pallet-transaction-payment-free = { default-features = false, version = '2.0.0', package = 'pallet-transaction-payment-free', path = '../pallets/transaction-payment-free' }
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dscp-node-runtime"
-version = "4.3.2"
+version = "4.3.0"
 authors = ["Digital Catapult <https://www.digicatapult.org.uk>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -95,7 +95,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("dscp"),
     impl_name: create_runtime_str!("dscp"),
     authoring_version: 1,
-    spec_version: 432,
+    spec_version: 430,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -7,7 +7,7 @@
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 use codec::{Decode, Encode, MaxEncodedLen};
-use frame_support::traits::{ConstU128, ConstU32, ConstU64, ConstU8, EitherOfDiverse, EqualPrivilegeOnly};
+use frame_support::traits::{ConstU128, ConstU32, ConstU64, EitherOfDiverse, EqualPrivilegeOnly};
 use frame_support::BoundedVec;
 use frame_system::EnsureRoot;
 use pallet_grandpa::fg_primitives;
@@ -95,7 +95,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("dscp"),
     impl_name: create_runtime_str!("dscp"),
     authoring_version: 1,
-    spec_version: 422,
+    spec_version: 432,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,
@@ -380,8 +380,7 @@ impl pallet_process_validation::Config for Runtime {
     type TokenMetadataKey = TokenMetadataKey;
     type TokenMetadataValue = TokenMetadataValue;
     type TokenMetadataValueDiscriminator = MetadataValueType;
-    type MaxRestrictionDepth = ConstU8<3>;
-    type MaxProcessRestrictions = ConstU32<100>;
+    type MaxProcessProgramLength = ConstU32<200>;
 }
 
 parameter_types! {


### PR DESCRIPTION
Re-enables the functionality that used to be encoded in the Combined restriction type. To avoid circular type references and to simplify the API this has instead been achieved by abstracting out the way restricitons are combined. Previously top-level we assumed that restrictions should be 'AND'ed together. Now an arbitrary binary expression tree is used  written in postfix notation.

Also added are a Fail restriction type which always fails to pass. This is useful both for testing and for doing certain unary operations as the tree only excepts binary operations.

There is some opinionation as to what the defaul should be for the Process program. This change maintains current behaviour that the program will always succeed.