### PR TITLE
Update deprecated actions

### DIFF
--- a/.github/workflows/check-and-test.yml
+++ b/.github/workflows/check-and-test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Get Toolchain Version
         id: get_toolchain
         run: |
-          echo "##[set-output name=TOOLCHAIN;]$(cat rust-toolchain)"
+          echo "TOOLCHAIN=$(cat rust-toolchain)" >> $GITHUB_OUTPUT
 
   check-helm-version:
     name: Check helm version

--- a/.github/workflows/check-and-test.yml
+++ b/.github/workflows/check-and-test.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Install rustfmt
         run: rustup component add rustfmt
       - name: Cache cargo registry
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}-${{ github.sha }}
@@ -97,7 +97,7 @@ jobs:
             ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
             ${{ runner.os }}-cargo-registry-
       - name: Cache cargo index
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}-${{ github.sha }}
@@ -105,7 +105,7 @@ jobs:
             ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
             ${{ runner.os }}-cargo-index-
       - name: Cache sccache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ runner.temp }}/cache
           key: ${{ runner.os }}-cargo-build-cache-debug-${{ hashFiles('**/Cargo.lock') }}-${{ github.sha }}

--- a/.github/workflows/check-and-test.yml
+++ b/.github/workflows/check-and-test.yml
@@ -13,7 +13,7 @@ jobs:
       toolchain: ${{ steps.get_toolchain.outputs.TOOLCHAIN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - run: git fetch --tags
@@ -31,7 +31,7 @@ jobs:
     name: Check helm version
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: git fetch --depth=1 --tags origin
       - name: Install yq
         run: sudo snap install yq
@@ -48,14 +48,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v3
         with:
           version: v3.4.0
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.7
       - name: Set up chart-testing
@@ -69,7 +69,7 @@ jobs:
     needs: [get-version]
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
       - name: Install latest nightly
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -29,8 +29,8 @@ jobs:
         run: |
           REPO_NAME=$(echo "${{ github.event.repository.name }}" | tr '[:upper:]' '[:lower:]')
           ORG_NAME=$(echo "${{ github.event.repository.owner.name }}" | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=REPO_NAME::$REPO_NAME"
-          echo "::set-output name=ORG_NAME::$ORG_NAME"
+          echo "REPO_NAME=$REPO_NAME" >> $GITHUB_OUTPUT
+          echo "ORG_NAME=$ORG_NAME" >> $GITHUB_OUTPUT
 
 
   helm-lint:
@@ -129,7 +129,7 @@ jobs:
       - name: Get toolchain version
         id: get_toolchain
         run: |
-          echo "##[set-output name=TOOLCHAIN;]$(cat rust-toolchain)"
+          echo "TOOLCHAIN=$(cat rust-toolchain)" >> $GITHUB_OUTPUT
       - name: Skipping release as version has not increased
         if: steps.get_version.outputs.IS_NEW_VERSION != 'true'
         shell: bash

--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -15,7 +15,7 @@ jobs:
       org_name: ${{ steps.repo_ids.outputs.ORG_NAME }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Check token
@@ -38,14 +38,14 @@ jobs:
     needs: [preconditions]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v3
         with:
           version: v3.4.0
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.7
       - name: Set up chart-testing
@@ -60,23 +60,23 @@ jobs:
   #     - check-version
   #   steps:
   #     - name: Checkout
-  #       uses: actions/checkout@v2
+  #       uses: actions/checkout@v3
   #       with:
   #         fetch-depth: 0
   #     - name: Setup QEMU
-  #       uses: docker/setup-qemu-action@v1
+  #       uses: docker/setup-qemu-action@v2
   #       with:
   #         platforms: all
   #     - name: Setup Docker Buildx
   #       id: buildx
-  #       uses: docker/setup-buildx-action@v1
+  #       uses: docker/setup-buildx-action@v2
   #       with:
   #         buildkitd-flags: "--debug"
   #     - name: Set up Helm
-  #       uses: azure/setup-helm@v1
+  #       uses: azure/setup-helm@v3
   #       with:
   #         version: v3.4.0
-  #     - uses: actions/setup-python@v2
+  #     - uses: actions/setup-python@v4
   #       with:
   #         python-version: 3.7
   #     - name: Set up chart-testing
@@ -89,7 +89,7 @@ jobs:
   #     - name: Login to minikube docker registry
   #       run: eval $(minikube -p minikube docker-env)
   #     - name: Build and Publish image
-  #       uses: docker/build-push-action@v2
+  #       uses: docker/build-push-action@v3
   #       with:
   #         builder: ${{ steps.buildx.outputs.name }}
   #         context: .
@@ -118,7 +118,7 @@ jobs:
       build_date: ${{ steps.get_version.outputs.BUILD_DATE }}
       toolchain: ${{ steps.get_toolchain.outputs.TOOLCHAIN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: git fetch --depth=1 --tags origin
       - name: Install yq
         run: sudo snap install yq
@@ -147,7 +147,7 @@ jobs:
     if: ${{ needs.check-version.outputs.is_new_version == 'true' }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Publish Helm charts
         uses: stefanprodan/helm-gh-pages@master

--- a/.github/workflows/release-types-package.yml
+++ b/.github/workflows/release-types-package.yml
@@ -32,8 +32,8 @@ jobs:
         run: |
           REPO_NAME=$(echo "${{ github.event.repository.name }}" | tr '[:upper:]' '[:lower:]')
           ORG_NAME=$(echo "${{ github.event.repository.owner.name }}" | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=REPO_NAME::$REPO_NAME"
-          echo "::set-output name=ORG_NAME::$ORG_NAME"
+          echo "REPO_NAME=$REPO_NAME" >> $GITHUB_OUTPUT
+          echo "ORG_NAME=$ORG_NAME" >> $GITHUB_OUTPUT
 
   lint:
     name: Run lint

--- a/.github/workflows/release-types-package.yml
+++ b/.github/workflows/release-types-package.yml
@@ -12,7 +12,7 @@ jobs:
       org_name: ${{ steps.repo_ids.outputs.ORG_NAME }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Check Github token
@@ -39,14 +39,14 @@ jobs:
     name: Run lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@master
         with:
           node-version: 16.x
       - name: Use npm v8
         run: npm install -g npm@8
       - name: Cache Node.js modules
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
           key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -65,14 +65,14 @@ jobs:
     name: Run dependency check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@master
         with:
           node-version: 16.x
       - name: Use npm v8
         run: npm install -g npm@8
       - name: Cache Node.js modules
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
           key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -95,7 +95,7 @@ jobs:
       build_date: ${{ steps.get_version.outputs.BUILD_DATE }}
       is_prerelease: ${{ steps.get_version.outputs.IS_PRERELEASE }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: git fetch --depth=1 --tags origin
       - name: Install yq
         run: pip3 install yq==2.13.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
           rm -rf $TEMP/sccache-v*-x86_64-unknown-linux-musl $TEMP/sccache-v*-x86_64-unknown-linux-musl.tar.gz $TEMP/fetch
           chmod +x $TEMP/sccache
       - name: Cache cargo registry
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}-${{ github.sha }}
@@ -76,7 +76,7 @@ jobs:
             ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
             ${{ runner.os }}-cargo-registry-
       - name: Cache cargo index
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}-${{ github.sha }}
@@ -84,7 +84,7 @@ jobs:
             ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
             ${{ runner.os }}-cargo-index-
       - name: Cache sccache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ runner.temp }}/cache
           key: ${{ runner.os }}-cargo-build-cache-release-${{ needs.get-version.outputs.toolchain }}-${{ needs.get-version.outputs.sane_branch_name_key }}-${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       toolchain: ${{ steps.get_toolchain.outputs.TOOLCHAIN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - run: git fetch --tags
@@ -50,7 +50,7 @@ jobs:
     if: ${{ needs.get-version.outputs.is_new_version == 'true' ||  needs.get-version.outputs.is_prerelease == 'true'}}
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
       - name: Install latest nightly
         uses: actions-rs/toolchain@v1
         with:
@@ -129,7 +129,7 @@ jobs:
             ${{ runner.temp }}/artefacts/dscp-node-${{ needs.get-version.outputs.version }}-runtime-wasm.tar.gz
       - name: Delete release latest
         if: ${{ needs.get-version.outputs.is_prerelease != 'true' }}
-        uses: actions/github-script@v5
+        uses: actions/github-script@v6
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
@@ -159,14 +159,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: [get-version, build-release]
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
     - name: Setup QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
       with:
         platforms: linux/amd64
     - name: Setup Docker Buildx
       id: buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
       with:
         buildkitd-flags: --debug
     - name: Generate tags
@@ -207,7 +207,7 @@ jobs:
         username: ${{ secrets.DSCP_DOCKERHUB_USERNAME }}
         password: ${{ secrets.DSCP_DOCKERHUB_TOKEN }}
     - name: Build image
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
         builder: ${{ steps.buildx.outputs.name }}
         context: .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Get Toolchain Version
         id: get_toolchain
         run: |
-          echo "##[set-output name=TOOLCHAIN;]$(cat rust-toolchain)"
+          echo "TOOLCHAIN=$(cat rust-toolchain)" >> $GITHUB_OUTPUT
 
   # Github releases are only performed when the release version changes
   build-release:
@@ -180,20 +180,20 @@ jobs:
       # if it's a non new version tag with hash and latest-dev
       run: |
         if [ "$IS_NEW_VERSION" == "true" ]; then
-          echo "##[set-output name=GHCR_VERSION_TAG;]ghcr.io/digicatapult/dscp-node:$VERSION";
-          echo "##[set-output name=DOCKERHUB_VERSION_TAG;]digicatapult/dscp-node:$VERSION";
+          echo "GHCR_VERSION_TAG=ghcr.io/digicatapult/dscp-node:$VERSION" >> $GITHUB_OUTPUT
+          echo "DOCKERHUB_VERSION_TAG=digicatapult/dscp-node:$VERSION" >> $GITHUB_OUTPUT
           if [ "$IS_PRERELEASE" == "false" ]; then
-            echo "##[set-output name=GHCR_LATEST_TAG;]ghcr.io/digicatapult/dscp-node:latest";
-            echo "##[set-output name=DOCKERHUB_LATEST_TAG;]digicatapult/dscp-node:latest";
+            echo "GHCR_LATEST_TAG=ghcr.io/digicatapult/dscp-node:latest" >> $GITHUB_OUTPUT
+            echo "DOCKERHUB_LATEST_TAG=digicatapult/dscp-node:latest" >> $GITHUB_OUTPUT
           else
-            echo "##[set-output name=GHCR_LATEST_TAG;]";
-            echo "##[set-output name=DOCKERHUB_LATEST_TAG;]";
+            echo "GHCR_LATEST_TAG=" >> $GITHUB_OUTPUT
+            echo "DOCKERHUB_LATEST_TAG=" >> $GITHUB_OUTPUT
           fi;
         else
-          echo "##[set-output name=GHCR_VERSION_TAG;]";
-          echo "##[set-output name=GHCR_LATEST_TAG;]";
-          echo "##[set-output name=DOCKERHUB_VERSION_TAG;]";
-          echo "##[set-output name=DOCKERHUB_LATEST_TAG;]";
+          echo "GHCR_VERSION_TAG=" >> $GITHUB_OUTPUT
+          echo "GHCR_LATEST_TAG=" >> $GITHUB_OUTPUT
+          echo "DOCKERHUB_VERSION_TAG=" >> $GITHUB_OUTPUT       
+          echo "DOCKERHUB_LATEST_TAG=" >> $GITHUB_OUTPUT
         fi;
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v2

--- a/.github/workflows/test-types.yml
+++ b/.github/workflows/test-types.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
       - name: Install latest nightly
         uses: actions-rs/toolchain@v1
         with:
@@ -71,7 +71,7 @@ jobs:
       - name: Use npm v8
         run: npm install -g npm@8
       - name: Cache Node.js modules
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
           key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/test-types.yml
+++ b/.github/workflows/test-types.yml
@@ -30,7 +30,7 @@ jobs:
           rm -rf $TEMP/sccache-v*-x86_64-unknown-linux-musl $TEMP/sccache-v*-x86_64-unknown-linux-musl.tar.gz $TEMP/fetch
           chmod +x $TEMP/sccache
       - name: Cache cargo registry
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}-${{ github.sha }}
@@ -38,7 +38,7 @@ jobs:
             ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
             ${{ runner.os }}-cargo-registry-
       - name: Cache cargo index
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}-${{ github.sha }}
@@ -46,7 +46,7 @@ jobs:
             ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
             ${{ runner.os }}-cargo-index-
       - name: Cache sccache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ runner.temp }}/cache
           key: ${{ runner.os }}-cargo-build-cache-release-${{ needs.get-version.outputs.toolchain }}-${{ needs.get-version.outputs.sane_branch_name_key }}-${{ github.sha }}

--- a/.github/workflows/types-package.yml
+++ b/.github/workflows/types-package.yml
@@ -7,14 +7,14 @@ jobs:
     name: Run lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@master
         with:
           node-version: 16.x
       - name: Use npm v8
         run: npm install -g npm@8
       - name: Cache Node.js modules
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
           key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -33,14 +33,14 @@ jobs:
     name: Run dependency check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@master
         with:
           node-version: 16.x
       - name: Use npm v8
         run: npm install -g npm@8
       - name: Cache Node.js modules
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
           key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -58,7 +58,7 @@ jobs:
     name: 'Check version'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: git fetch --depth=1 --tags origin
       - name: Install yq
         run: pip3 install yq==2.13.0

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-node",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-node",
-      "version": "4.3.1",
+      "version": "4.3.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^8.11.3"

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-node",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "description": "DSCP node types",
   "repository": {
     "type": "git",

--- a/helm/dscp-node/Chart.yaml
+++ b/helm/dscp-node/Chart.yaml
@@ -6,5 +6,5 @@ maintainers:
     url: www.digicatapult.org.uk
 description: A Helm chart to deploy DSCP nodes
 type: application
-version: 4.3.1
-appVersion: "4.3.1"
+version: 4.3.2
+appVersion: "4.3.2"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -18,16 +18,10 @@ targets = ['x86_64-unknown-linux-gnu']
 clap = { version = "3.1.18", features = ["derive"] }
 bs58 = "0.4.0"
 
-sc-cli = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25", features = [
-    "wasmtime",
-] }
+sc-cli = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25", features = ["wasmtime"] }
 sp-core = { version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25" }
-sc-executor = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25", features = [
-    "wasmtime",
-] }
-sc-service = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25", features = [
-    "wasmtime",
-] }
+sc-executor = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25", features = ["wasmtime"]  }
+sc-service = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25", features = ["wasmtime"]  }
 sc-telemetry = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25" }
 sc-keystore = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25" }
 sc-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25" }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -61,7 +61,7 @@ frame-benchmarking = { version = "4.0.0-dev", git = "https://github.com/parityte
 frame-benchmarking-cli = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.30" }
 
 # Local Dependencies
-dscp-node-runtime = { path = '../runtime', version = '4.3.2' }
+dscp-node-runtime = { path = '../runtime', version = '4.4.1' }
 
 # CLI-specific dependencies
 try-runtime-cli = { version = "0.10.0-dev", optional = true, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.30" }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -6,7 +6,7 @@ edition = '2021'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/dscp-node/'
 name = 'dscp-node'
-version = '4.3.1'
+version = '4.3.2'
 
 [[bin]]
 name = 'dscp-node'
@@ -18,10 +18,16 @@ targets = ['x86_64-unknown-linux-gnu']
 clap = { version = "3.1.18", features = ["derive"] }
 bs58 = "0.4.0"
 
-sc-cli = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25", features = ["wasmtime"] }
+sc-cli = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25", features = [
+    "wasmtime",
+] }
 sp-core = { version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25" }
-sc-executor = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25", features = ["wasmtime"]  }
-sc-service = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25", features = ["wasmtime"]  }
+sc-executor = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25", features = [
+    "wasmtime",
+] }
+sc-service = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25", features = [
+    "wasmtime",
+] }
 sc-telemetry = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25" }
 sc-keystore = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25" }
 sc-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25" }
@@ -55,7 +61,7 @@ frame-benchmarking = { version = "4.0.0-dev", git = "https://github.com/parityte
 frame-benchmarking-cli = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25" }
 
 # Local Dependencies
-dscp-node-runtime = { path = '../runtime', version = '4.3.1' }
+dscp-node-runtime = { path = '../runtime', version = '4.3.2' }
 
 # CLI-specific dependencies
 try-runtime-cli = { version = "0.10.0-dev", optional = true, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25" }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -11,8 +11,12 @@ repository = "https://github.com/digicatapult/dscp-node/"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [
+    "derive",
+] }
+scale-info = { version = "2.1.1", default-features = false, features = [
+    "derive",
+] }
 
 pallet-aura = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25" }
 pallet-balances = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25" }
@@ -26,10 +30,10 @@ pallet-timestamp = { version = "4.0.0-dev", default-features = false, git = "htt
 pallet-transaction-payment-rpc-runtime-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25" }
 frame-executive = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25" }
 sp-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25" }
-sp-block-builder = {  version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25"}
+sp-block-builder = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25" }
 sp-consensus-aura = { version = "0.10.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25" }
 sp-core = { version = "6.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25" }
-sp-inherents = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25"}
+sp-inherents = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25" }
 sp-offchain = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25" }
 sp-runtime = { version = "6.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25" }
 sp-session = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25" }
@@ -117,23 +121,23 @@ runtime-benchmarks = [
     "sp-runtime/runtime-benchmarks",
 ]
 try-runtime = [
-	"frame-executive/try-runtime",
-	"frame-try-runtime",
-	"frame-system/try-runtime",
-	"pallet-aura/try-runtime",
-	"pallet-balances/try-runtime",
+    "frame-executive/try-runtime",
+    "frame-try-runtime",
+    "frame-system/try-runtime",
+    "pallet-aura/try-runtime",
+    "pallet-balances/try-runtime",
     "pallet-collective/try-runtime",
-	"pallet-doas/try-runtime",
-	"pallet-grandpa/try-runtime",
+    "pallet-doas/try-runtime",
+    "pallet-grandpa/try-runtime",
     "pallet-membership/try-runtime",
     "pallet-node-authorization/try-runtime",
     "pallet-preimage/try-runtime",
-	"pallet-process-validation/try-runtime",
-	"pallet-randomness-collective-flip/try-runtime",
+    "pallet-process-validation/try-runtime",
+    "pallet-randomness-collective-flip/try-runtime",
     "pallet-scheduler/try-runtime",
-	"pallet-simple-nft/try-runtime",
-	"pallet-sudo/try-runtime",
-	"pallet-symmetric-key/try-runtime",
-	"pallet-timestamp/try-runtime",
-	"pallet-transaction-payment-free/try-runtime",
+    "pallet-simple-nft/try-runtime",
+    "pallet-sudo/try-runtime",
+    "pallet-symmetric-key/try-runtime",
+    "pallet-timestamp/try-runtime",
+    "pallet-transaction-payment-free/try-runtime",
 ]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dscp-node-runtime"
-version = "4.3.1"
+version = "4.3.2"
 authors = ["Digital Catapult <https://www.digicatapult.org.uk>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -11,12 +11,8 @@ repository = "https://github.com/digicatapult/dscp-node/"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [
-    "derive",
-] }
-scale-info = { version = "2.1.1", default-features = false, features = [
-    "derive",
-] }
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 
 pallet-aura = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25" }
 pallet-balances = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25" }
@@ -30,10 +26,10 @@ pallet-timestamp = { version = "4.0.0-dev", default-features = false, git = "htt
 pallet-transaction-payment-rpc-runtime-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25" }
 frame-executive = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25" }
 sp-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25" }
-sp-block-builder = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25" }
+sp-block-builder = {  version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25"}
 sp-consensus-aura = { version = "0.10.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25" }
 sp-core = { version = "6.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25" }
-sp-inherents = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25" }
+sp-inherents = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25"}
 sp-offchain = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25" }
 sp-runtime = { version = "6.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25" }
 sp-session = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25" }
@@ -121,23 +117,23 @@ runtime-benchmarks = [
     "sp-runtime/runtime-benchmarks",
 ]
 try-runtime = [
-    "frame-executive/try-runtime",
-    "frame-try-runtime",
-    "frame-system/try-runtime",
-    "pallet-aura/try-runtime",
-    "pallet-balances/try-runtime",
+	"frame-executive/try-runtime",
+	"frame-try-runtime",
+	"frame-system/try-runtime",
+	"pallet-aura/try-runtime",
+	"pallet-balances/try-runtime",
     "pallet-collective/try-runtime",
-    "pallet-doas/try-runtime",
-    "pallet-grandpa/try-runtime",
+	"pallet-doas/try-runtime",
+	"pallet-grandpa/try-runtime",
     "pallet-membership/try-runtime",
     "pallet-node-authorization/try-runtime",
     "pallet-preimage/try-runtime",
-    "pallet-process-validation/try-runtime",
-    "pallet-randomness-collective-flip/try-runtime",
+	"pallet-process-validation/try-runtime",
+	"pallet-randomness-collective-flip/try-runtime",
     "pallet-scheduler/try-runtime",
-    "pallet-simple-nft/try-runtime",
-    "pallet-sudo/try-runtime",
-    "pallet-symmetric-key/try-runtime",
-    "pallet-timestamp/try-runtime",
-    "pallet-transaction-payment-free/try-runtime",
+	"pallet-simple-nft/try-runtime",
+	"pallet-sudo/try-runtime",
+	"pallet-symmetric-key/try-runtime",
+	"pallet-timestamp/try-runtime",
+	"pallet-transaction-payment-free/try-runtime",
 ]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -95,7 +95,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("dscp"),
     impl_name: create_runtime_str!("dscp"),
     authoring_version: 1,
-    spec_version: 431,
+    spec_version: 432,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/scripts/check-helm-version.sh
+++ b/scripts/check-helm-version.sh
@@ -31,9 +31,9 @@ yq eval '.entries.[env(REPOSITORY_NAME)] | .[0].version' -)
 CURRENT_VERSION=$(yq eval '.version' ./helm/dscp-node/Chart.yaml)
 
 if check_version_greater "$CURRENT_VERSION" "$PUBLISHED_VERSIONS"; then
-  echo "##[set-output name=VERSION;]$CURRENT_VERSION"
-  echo "##[set-output name=BUILD_DATE;]$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
-  echo "##[set-output name=IS_NEW_VERSION;]true"
+  echo "VERSION=v$CURRENT_VERSION" >> $GITHUB_OUTPUT
+  echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
+  echo "IS_NEW_VERSION=true" >> $GITHUB_OUTPUT
 else
-  echo "##[set-output name=IS_NEW_VERSION;]false"
+  echo "IS_NEW_VERSION=false" >> $GITHUB_OUTPUT
 fi

--- a/scripts/check-package-version.sh
+++ b/scripts/check-package-version.sh
@@ -46,16 +46,16 @@ PUBLISHED_VERSIONS=$(git tag | grep "^v[0-9]\+\.[0-9]\+\.[0-9]\+\(\-[a-zA-Z-]\+\
 CURRENT_VERSION=$(yq '.version' ./api/package.json)
 
 if check_version_greater "$CURRENT_VERSION" "$PUBLISHED_VERSIONS"; then
-  echo "##[set-output name=VERSION;]v$CURRENT_VERSION"
-  echo "##[set-output name=BUILD_DATE;]$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
-  echo "##[set-output name=IS_NEW_VERSION;]true"
+  echo "VERSION=v$CURRENT_VERSION" >> $GITHUB_OUTPUT
+  echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
+  echo "IS_NEW_VERSION=true" >> $GITHUB_OUTPUT
   if [[ $CURRENT_VERSION =~ [-] ]]; then
-    echo "##[set-output name=IS_PRERELEASE;]true"
-    echo "##[set-output name=NPM_RELEASE_TAG;]next"
+    echo "IS_PRERELEASE=true" >> $GITHUB_OUTPUT
+    echo "NPM_RELEASE_TAG=next" >> $GITHUB_OUTPUT
   else
-    echo "##[set-output name=IS_PRERELEASE;]false"
-    echo "##[set-output name=NPM_RELEASE_TAG;]latest"
+    echo "IS_PRERELEASE=false" >> $GITHUB_OUTPUT
+    echo "NPM_RELEASE_TAG=latest" >> $GITHUB_OUTPUT
   fi
 else
-  echo "##[set-output name=IS_NEW_VERSION;]false"
+  echo "IS_NEW_VERSION=false" >> $GITHUB_OUTPUT
 fi

--- a/scripts/check-version.sh
+++ b/scripts/check-version.sh
@@ -79,18 +79,18 @@ PUBLISHED_VERSIONS=$(git tag | grep "^v[0-9]\+\.[0-9]\+\.[0-9]\+\(\-[a-zA-Z-]\+\
 
 get_working_copy_version
 
-echo "##[set-output name=VERSION;]v$CURRENT_VERSION"
-echo "##[set-output name=SANE_BRANCH_NAME_KEY;]$SANE_BRANCH_NAME_KEY"
-echo "##[set-output name=BUILD_DATE;]$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+echo "VERSION=v$CURRENT_VERSION" >> $GITHUB_OUTPUT
+echo "SANE_BRANCH_NAME_KEY=$SANE_BRANCH_NAME_KEY" >> $GITHUB_OUTPUT
+echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
 
 if check_version_greater "$CURRENT_VERSION" "$PUBLISHED_VERSIONS"; then
-  echo "##[set-output name=IS_NEW_VERSION;]true"
+  echo "IS_NEW_VERSION=true" >> $GITHUB_OUTPUT
 else
-  echo "##[set-output name=IS_NEW_VERSION;]false"
+  echo "IS_NEW_VERSION=false" >> $GITHUB_OUTPUT
 fi
 
 if [ $IS_PRERELEASE ]; then
-  echo "##[set-output name=IS_PRERELEASE;]true"
+  echo "IS_NEW_VERSION=true" >> $GITHUB_OUTPUT
 else
-  echo "##[set-output name=IS_PRERELEASE;]false"
+  echo "IS_NEW_VERSION=false" >> $GITHUB_OUTPUT
 fi


### PR DESCRIPTION
See reduced number of annotations https://github.com/digicatapult/dscp-node/actions/runs/3321131708. 
`rustup` and `cargo` actions still use node 12 for now [ticket](https://digicatapult.atlassian.net/browse/IN-401)
Explanation for remaining warnings https://github.com/digicatapult/dscp-api/pull/60