### PR TITLE
Add benchmarks and weights for pallet-process-validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1296,7 +1296,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "dscp-node"
-version = "4.4.0"
+version = "4.4.2"
 dependencies = [
  "bs58",
  "clap",
@@ -1339,7 +1339,7 @@ dependencies = [
 
 [[package]]
 name = "dscp-node-runtime"
-version = "4.4.0"
+version = "4.4.2"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-node",
-  "version": "4.4.0",
+  "version": "4.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-node",
-      "version": "4.4.0",
+      "version": "4.4.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^8.11.3"

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-node",
-  "version": "4.4.0",
+  "version": "4.4.2",
   "description": "DSCP node types",
   "repository": {
     "type": "git",

--- a/helm/dscp-node/Chart.yaml
+++ b/helm/dscp-node/Chart.yaml
@@ -6,5 +6,5 @@ maintainers:
     url: www.digicatapult.org.uk
 description: A Helm chart to deploy DSCP nodes
 type: application
-version: 4.4.0
-appVersion: '4.4.0'
+version: 4.4.2
+appVersion: '4.4.2'

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -6,7 +6,7 @@ edition = '2021'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/dscp-node/'
 name = 'dscp-node'
-version = '4.4.0'
+version = '4.4.2'
 
 [[bin]]
 name = 'dscp-node'
@@ -19,14 +19,14 @@ clap = { version = "3.1.18", features = ["derive"] }
 bs58 = "0.4.0"
 
 sc-cli = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.30", features = [
-  "wasmtime",
+    "wasmtime",
 ] }
 sp-core = { version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.30" }
 sc-executor = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.30", features = [
-  "wasmtime",
+    "wasmtime",
 ] }
 sc-service = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.30", features = [
-  "wasmtime",
+    "wasmtime",
 ] }
 sc-telemetry = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.30" }
 sc-keystore = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.30" }
@@ -61,7 +61,7 @@ frame-benchmarking = { version = "4.0.0-dev", git = "https://github.com/parityte
 frame-benchmarking-cli = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.30" }
 
 # Local Dependencies
-dscp-node-runtime = { path = '../runtime', version = '4.3.1' }
+dscp-node-runtime = { path = '../runtime', version = '4.4.2' }
 
 # CLI-specific dependencies
 try-runtime-cli = { version = "0.10.0-dev", optional = true, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.30" }
@@ -74,9 +74,9 @@ substrate-build-script-utils = { version = "3.0.0", git = "https://github.com/pa
 [features]
 default = []
 runtime-benchmarks = [
-  "dscp-node-runtime/runtime-benchmarks",
-  "frame-benchmarking/runtime-benchmarks",
-  "frame-benchmarking-cli/runtime-benchmarks",
+    "dscp-node-runtime/runtime-benchmarks",
+    "frame-benchmarking/runtime-benchmarks",
+    "frame-benchmarking-cli/runtime-benchmarks",
 ]
 # Enable features that allow the runtime to be tried and debugged. Name might be subject to change
 # in the near future.

--- a/pallets/process-validation/src/benchmarking.rs
+++ b/pallets/process-validation/src/benchmarking.rs
@@ -9,6 +9,7 @@ use crate::Pallet as ProcessValidation;
 
 benchmarks! {
   create_process {
+    // valid programs have x Restrictions and (x-1) Ops, therefore number of BooleanExpressionSymbol to add is always odd
     let r in 1 .. (1 + T::MaxProcessProgramLength::get() / 2);
 
     let mut program = BoundedVec::<_, _>::with_bounded_capacity(T::MaxProcessProgramLength::get() as usize);
@@ -19,9 +20,7 @@ benchmarks! {
         program.try_push(BooleanExpressionSymbol::Op(BooleanOperator::And)).unwrap();
     }
 
-  }: _(RawOrigin::Root,
-  T::ProcessIdentifier::default(),
-  program.clone())
+  }: _(RawOrigin::Root, T::ProcessIdentifier::default(), program.clone())
   verify {
     let version = VersionModel::<T>::get(T::ProcessIdentifier::default());
     let process = ProcessModel::<T>::get(T::ProcessIdentifier::default(), version);
@@ -30,19 +29,20 @@ benchmarks! {
   }
 
   disable_process {
-    let mut program = BoundedVec::<_, _>::with_bounded_capacity(1);
+    let mut program = BoundedVec::<_, _>::with_bounded_capacity(T::MaxProcessProgramLength::get() as usize);
     program.try_push(BooleanExpressionSymbol::Restriction(Restriction::None)).unwrap();
 
       ProcessValidation::<T>::create_process(
             RawOrigin::Root.into(),
             T::ProcessIdentifier::default(),
-            program,
-        );
-  }: _(RawOrigin::Root, T::ProcessIdentifier::default(), One::one())
+            program.clone(),
+        ).unwrap();
+  }: _(RawOrigin::Root, T::ProcessIdentifier::default(), 1u32.into())
   verify {
-    // let version = ProcessValidation::<T>::get_version(&T::ProcessIdentifier::default());
-    // let process = ProcessModel::<T>::get(T::ProcessIdentifier::default(), version);
-    // assert_eq!(process.status, ProcessStatus::Disabled)
+    let version = VersionModel::<T>::get(T::ProcessIdentifier::default());
+    let process = ProcessModel::<T>::get(T::ProcessIdentifier::default(), version);
+    assert_eq!(process.status, ProcessStatus::Disabled);
+    assert_eq!(process.program, program);
   }
 }
 impl_benchmark_test_suite!(ProcessValidation, crate::mock::new_test_ext(), crate::mock::Test,);

--- a/pallets/process-validation/src/benchmarking.rs
+++ b/pallets/process-validation/src/benchmarking.rs
@@ -32,11 +32,12 @@ benchmarks! {
     let mut program = BoundedVec::<_, _>::with_bounded_capacity(T::MaxProcessProgramLength::get() as usize);
     program.try_push(BooleanExpressionSymbol::Restriction(Restriction::None)).unwrap();
 
-      ProcessValidation::<T>::create_process(
-            RawOrigin::Root.into(),
-            T::ProcessIdentifier::default(),
-            program.clone(),
-        ).unwrap();
+    ProcessValidation::<T>::create_process(
+          RawOrigin::Root.into(),
+          T::ProcessIdentifier::default(),
+          program.clone(),
+      ).unwrap();
+
   }: _(RawOrigin::Root, T::ProcessIdentifier::default(), 1u32.into())
   verify {
     let version = VersionModel::<T>::get(T::ProcessIdentifier::default());

--- a/pallets/process-validation/src/benchmarking.rs
+++ b/pallets/process-validation/src/benchmarking.rs
@@ -1,7 +1,6 @@
 // ! Benchmarking setup for pallet-template
 
 use super::*;
-
 use frame_benchmarking::{benchmarks, impl_benchmark_test_suite};
 use frame_support::bounded_vec;
 use frame_system::RawOrigin;
@@ -11,15 +10,26 @@ use crate::Pallet as ProcessValidation;
 
 // TODO implement benchmarking
 benchmarks! {
-  create_process {
-  }: _(RawOrigin::Root, T::ProcessIdentifier::default(), bounded_vec![])
-  verify {
-  }
+  // create_process {
+  // }: _(RawOrigin::Root, T::ProcessIdentifier::default(), bounded_vec![])
+  // verify {
+  // }
 
   disable_process {
+      ProcessValidation::<T>::create_process(
+            RawOrigin::Root.into(),
+            T::ProcessIdentifier::default(),
+            bounded_vec![BooleanExpressionSymbol::Restriction(Restriction::None)],
+        );
   }: _(RawOrigin::Root, T::ProcessIdentifier::default(), One::one())
   verify {
+    // assert_eq!(
+      // ProcessModel::<T>::get(T::ProcessIdentifier::default(), One::one()),
+      // Process {
+      //     status: ProcessStatus::Disabled,
+      //     program: bounded_vec![BooleanExpressionSymbol::Restriction(Restriction::None)]
+      // }
+  //)
   }
 }
-
 impl_benchmark_test_suite!(ProcessValidation, crate::mock::new_test_ext(), crate::mock::Test,);

--- a/pallets/process-validation/src/benchmarking.rs
+++ b/pallets/process-validation/src/benchmarking.rs
@@ -12,16 +12,24 @@ benchmarks! {
     let i in 1..200;
 
     let mut program = BoundedVec::<_, _>::with_bounded_capacity(i as usize);
-    for _ in 1..i {
-      program.try_push(BooleanExpressionSymbol::Restriction(Restriction::None)).unwrap();
+    for j in 0..i {
+      if j == 0 {
+        program.try_push(BooleanExpressionSymbol::Restriction(Restriction::None)).unwrap();
+      }
+      // add every other loop to have valid postfix notation
+      else if j % 2 == 0 {
+        program.try_push(BooleanExpressionSymbol::Restriction(Restriction::None)).unwrap();
+        program.try_push(BooleanExpressionSymbol::Op(BooleanOperator::And)).unwrap();
+      }
     }
 
   }: _(RawOrigin::Root,
   T::ProcessIdentifier::default(),
   program.clone())
   verify {
-    let version = ProcessValidation::<T>::get_version(&T::ProcessIdentifier::default());
-    assert_eq!(version, i.into());
+    // let version = ProcessValidation::<T>::get_version(&T::ProcessIdentifier::default());
+    // let process = ProcessModel::<T>::get(T::ProcessIdentifier::default(), version);
+    // assert_eq!(process.status, ProcessStatus::Enabled)
   }
 
   disable_process {
@@ -35,9 +43,9 @@ benchmarks! {
         );
   }: _(RawOrigin::Root, T::ProcessIdentifier::default(), One::one())
   verify {
-    let version = ProcessValidation::<T>::get_version(&T::ProcessIdentifier::default());
-    let process = ProcessModel::<T>::get(T::ProcessIdentifier::default(), version);
-    assert_eq!(process.status, ProcessStatus::Disabled)
+    // let version = ProcessValidation::<T>::get_version(&T::ProcessIdentifier::default());
+    // let process = ProcessModel::<T>::get(T::ProcessIdentifier::default(), version);
+    // assert_eq!(process.status, ProcessStatus::Disabled)
   }
 }
 impl_benchmark_test_suite!(ProcessValidation, crate::mock::new_test_ext(), crate::mock::Test,);

--- a/pallets/process-validation/src/benchmarking.rs
+++ b/pallets/process-validation/src/benchmarking.rs
@@ -1,8 +1,7 @@
 // ! Benchmarking setup for pallet-template
-
 use super::*;
 use frame_benchmarking::{benchmarks, impl_benchmark_test_suite};
-use frame_support::bounded_vec;
+use frame_support::{BoundedVec};
 use frame_system::RawOrigin;
 
 #[allow(unused)]
@@ -16,10 +15,13 @@ benchmarks! {
   // }
 
   disable_process {
+    let mut program = BoundedVec::<_, _>::with_bounded_capacity(1);
+    program.try_push(BooleanExpressionSymbol::Restriction(Restriction::None)).unwrap();
+
       ProcessValidation::<T>::create_process(
             RawOrigin::Root.into(),
             T::ProcessIdentifier::default(),
-            bounded_vec![BooleanExpressionSymbol::Restriction(Restriction::None)],
+            program,
         );
   }: _(RawOrigin::Root, T::ProcessIdentifier::default(), One::one())
   verify {
@@ -27,7 +29,7 @@ benchmarks! {
       // ProcessModel::<T>::get(T::ProcessIdentifier::default(), One::one()),
       // Process {
       //     status: ProcessStatus::Disabled,
-      //     program: bounded_vec![BooleanExpressionSymbol::Restriction(Restriction::None)]
+      //     program: BoundedVec::<_, _>::with_bounded_capacity(0),
       // }
   //)
   }

--- a/pallets/process-validation/src/binary_expression_tree.rs
+++ b/pallets/process-validation/src/binary_expression_tree.rs
@@ -3,8 +3,7 @@ use scale_info::TypeInfo;
 
 use crate::Restriction;
 
-#[derive(Encode, Decode, Clone, MaxEncodedLen, TypeInfo, PartialEq)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Encode, Decode, Debug, Clone, MaxEncodedLen, TypeInfo, PartialEq)]
 pub enum BooleanOperator {
     Null,         // false
     Identity,     // true
@@ -24,8 +23,7 @@ pub enum BooleanOperator {
     InhibitionR   // B and !A
 }
 
-#[derive(Encode, Decode, Clone, MaxEncodedLen, TypeInfo, PartialEq)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Encode, Decode, Debug, Clone, MaxEncodedLen, TypeInfo, PartialEq)]
 pub enum BooleanExpressionSymbol<RoleKey, TokenMetadataKey, TokenMetadataValue, TokenMetadataValueDiscriminator> {
     Op(BooleanOperator),
     Restriction(Restriction<RoleKey, TokenMetadataKey, TokenMetadataValue, TokenMetadataValueDiscriminator>)

--- a/pallets/process-validation/src/lib.rs
+++ b/pallets/process-validation/src/lib.rs
@@ -22,8 +22,7 @@ use restrictions::*;
 mod binary_expression_tree;
 use binary_expression_tree::*;
 
-#[derive(Encode, Decode, Clone, MaxEncodedLen, TypeInfo, PartialEq)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Encode, Debug, Decode, Clone, MaxEncodedLen, TypeInfo, PartialEq)]
 pub enum ProcessStatus {
     Disabled,
     Enabled

--- a/pallets/process-validation/src/lib.rs
+++ b/pallets/process-validation/src/lib.rs
@@ -191,7 +191,7 @@ pub mod pallet {
     // The pallet's dispatchable functions.
     #[pallet::call]
     impl<T: Config> Pallet<T> {
-        #[pallet::weight(T::WeightInfo::create_process())]
+        #[pallet::weight(T::WeightInfo::create_process(program.len()))]
         pub fn create_process(
             origin: OriginFor<T>,
             id: T::ProcessIdentifier,

--- a/pallets/process-validation/src/lib.rs
+++ b/pallets/process-validation/src/lib.rs
@@ -260,15 +260,16 @@ pub mod pallet {
             executed_stack_height == Some(1u8)
         }
 
-        pub fn get_version(id: &T::ProcessIdentifier) -> T::ProcessVersion {
-            return match <VersionModel<T>>::contains_key(&id) {
-                true => <VersionModel<T>>::get(&id) + One::one(),
-                false => One::one()
+        pub fn get_next_version(id: &T::ProcessIdentifier) -> T::ProcessVersion {
+            let current_version = <VersionModel<T>>::try_get(&id);
+            return match current_version {
+                Ok(version) => version + One::one(),
+                Err(_) => One::one()
             };
         }
 
         pub fn update_version(id: T::ProcessIdentifier) -> Result<T::ProcessVersion, Error<T>> {
-            let version: T::ProcessVersion = Pallet::<T>::get_version(&id);
+            let version: T::ProcessVersion = Pallet::<T>::get_next_version(&id);
             match version == One::one() {
                 true => <VersionModel<T>>::insert(&id, version.clone()),
                 false => <VersionModel<T>>::mutate(&id, |v| *v = version.clone())

--- a/pallets/process-validation/src/lib.rs
+++ b/pallets/process-validation/src/lib.rs
@@ -191,7 +191,7 @@ pub mod pallet {
     // The pallet's dispatchable functions.
     #[pallet::call]
     impl<T: Config> Pallet<T> {
-        #[pallet::weight(T::WeightInfo::create_process(program.len()))]
+        #[pallet::weight(T::WeightInfo::create_process(program.len() as u32))]
         pub fn create_process(
             origin: OriginFor<T>,
             id: T::ProcessIdentifier,

--- a/pallets/process-validation/src/restrictions.rs
+++ b/pallets/process-validation/src/restrictions.rs
@@ -7,8 +7,7 @@ use frame_support::Parameter;
 use scale_info::TypeInfo;
 use sp_std::vec::Vec;
 
-#[derive(Encode, Decode, Clone, MaxEncodedLen, TypeInfo, PartialEq)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Encode, Decode, Debug, Clone, MaxEncodedLen, TypeInfo, PartialEq)]
 pub enum Restriction<RoleKey, TokenMetadataKey, TokenMetadataValue, TokenMetadataValueDiscriminator> {
     None,
     Fail,

--- a/pallets/process-validation/src/weights.rs
+++ b/pallets/process-validation/src/weights.rs
@@ -1,27 +1,34 @@
-#![allow(unused_parens)]
-#![allow(unused_imports)]
-
 use frame_support::{traits::Get, weights::Weight};
 use sp_std::marker::PhantomData;
 
 pub trait WeightInfo {
-    fn create_process() -> Weight;
+    fn create_process(i: usize) -> Weight;
     fn disable_process() -> Weight;
 }
 
-/// TODO implement weights after benchmarking
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
-    fn create_process() -> Weight {
-        Weight::from_ref_time(0 as u64)
+    // Storage: ProcessValidation VersionModel (r:1 w:1)
+    // Storage: ProcessValidation ProcessModel (r:1 w:1)
+    /// The range of component `i` is `[1, 200]`.
+    fn create_process(i: usize) -> Weight {
+        Weight::from_ref_time(25_000_000 as u64)
+            // Standard Error: 156
+            .saturating_add(Weight::from_ref_time(91_785 as u64).saturating_mul(i as u64))
+            .saturating_add(T::DbWeight::get().reads(2 as u64))
+            .saturating_add(T::DbWeight::get().writes(2 as u64))
     }
+    // Storage: ProcessValidation ProcessModel (r:1 w:1)
+    // Storage: ProcessValidation VersionModel (r:1 w:0)
     fn disable_process() -> Weight {
-        Weight::from_ref_time(0 as u64)
+        Weight::from_ref_time(34_000_000 as u64)
+            .saturating_add(T::DbWeight::get().reads(2 as u64))
+            .saturating_add(T::DbWeight::get().writes(1 as u64))
     }
 }
 
 impl WeightInfo for () {
-    fn create_process() -> Weight {
+    fn create_process(_: usize) -> Weight {
         Weight::from_ref_time(0 as u64)
     }
     fn disable_process() -> Weight {

--- a/pallets/process-validation/src/weights.rs
+++ b/pallets/process-validation/src/weights.rs
@@ -8,23 +8,23 @@ pub trait WeightInfo {
 
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
-	// Storage: ProcessValidation VersionModel (r:1 w:1)
-	// Storage: ProcessValidation ProcessModel (r:1 w:1)
-	/// The range of component `r` is `[1, 101]`.
-	fn create_process(r: u32, ) -> Weight {
-		Weight::from_ref_time(28_000_000 as u64)
-			// Standard Error: 1_911
-			.saturating_add(Weight::from_ref_time(147_095 as u64).saturating_mul(r as u64))
-			.saturating_add(T::DbWeight::get().reads(2 as u64))
-			.saturating_add(T::DbWeight::get().writes(2 as u64))
-	}
-	// Storage: ProcessValidation ProcessModel (r:1 w:1)
-	// Storage: ProcessValidation VersionModel (r:1 w:0)
-	fn disable_process() -> Weight {
-		Weight::from_ref_time(33_000_000 as u64)
-			.saturating_add(T::DbWeight::get().reads(2 as u64))
-			.saturating_add(T::DbWeight::get().writes(1 as u64))
-	}
+    // Storage: ProcessValidation VersionModel (r:1 w:1)
+    // Storage: ProcessValidation ProcessModel (r:1 w:1)
+    /// The range of component `r` is `[1, 101]`.
+    fn create_process(r: u32) -> Weight {
+        Weight::from_ref_time(28_000_000 as u64)
+            // Standard Error: 1_911
+            .saturating_add(Weight::from_ref_time(147_095 as u64).saturating_mul(r as u64))
+            .saturating_add(T::DbWeight::get().reads(2 as u64))
+            .saturating_add(T::DbWeight::get().writes(2 as u64))
+    }
+    // Storage: ProcessValidation ProcessModel (r:1 w:1)
+    // Storage: ProcessValidation VersionModel (r:1 w:0)
+    fn disable_process() -> Weight {
+        Weight::from_ref_time(33_000_000 as u64)
+            .saturating_add(T::DbWeight::get().reads(2 as u64))
+            .saturating_add(T::DbWeight::get().writes(1 as u64))
+    }
 }
 
 impl WeightInfo for () {

--- a/pallets/process-validation/src/weights.rs
+++ b/pallets/process-validation/src/weights.rs
@@ -2,7 +2,7 @@ use frame_support::{traits::Get, weights::Weight};
 use sp_std::marker::PhantomData;
 
 pub trait WeightInfo {
-    fn create_process(i: usize) -> Weight;
+    fn create_process(i: u32) -> Weight;
     fn disable_process() -> Weight;
 }
 
@@ -11,7 +11,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
     // Storage: ProcessValidation VersionModel (r:1 w:1)
     // Storage: ProcessValidation ProcessModel (r:1 w:1)
     /// The range of component `i` is `[1, 200]`.
-    fn create_process(i: usize) -> Weight {
+    fn create_process(i: u32) -> Weight {
         Weight::from_ref_time(25_000_000 as u64)
             // Standard Error: 156
             .saturating_add(Weight::from_ref_time(91_785 as u64).saturating_mul(i as u64))
@@ -28,7 +28,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 }
 
 impl WeightInfo for () {
-    fn create_process(_: usize) -> Weight {
+    fn create_process(_: u32) -> Weight {
         Weight::from_ref_time(0 as u64)
     }
     fn disable_process() -> Weight {

--- a/pallets/process-validation/src/weights.rs
+++ b/pallets/process-validation/src/weights.rs
@@ -8,23 +8,23 @@ pub trait WeightInfo {
 
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
-    // Storage: ProcessValidation VersionModel (r:1 w:1)
-    // Storage: ProcessValidation ProcessModel (r:1 w:1)
-    /// The range of component `i` is `[1, 200]`.
-    fn create_process(i: u32) -> Weight {
-        Weight::from_ref_time(25_000_000 as u64)
-            // Standard Error: 156
-            .saturating_add(Weight::from_ref_time(91_785 as u64).saturating_mul(i as u64))
-            .saturating_add(T::DbWeight::get().reads(2 as u64))
-            .saturating_add(T::DbWeight::get().writes(2 as u64))
-    }
-    // Storage: ProcessValidation ProcessModel (r:1 w:1)
-    // Storage: ProcessValidation VersionModel (r:1 w:0)
-    fn disable_process() -> Weight {
-        Weight::from_ref_time(34_000_000 as u64)
-            .saturating_add(T::DbWeight::get().reads(2 as u64))
-            .saturating_add(T::DbWeight::get().writes(1 as u64))
-    }
+	// Storage: ProcessValidation VersionModel (r:1 w:1)
+	// Storage: ProcessValidation ProcessModel (r:1 w:1)
+	/// The range of component `r` is `[1, 101]`.
+	fn create_process(r: u32, ) -> Weight {
+		Weight::from_ref_time(28_000_000 as u64)
+			// Standard Error: 1_911
+			.saturating_add(Weight::from_ref_time(147_095 as u64).saturating_mul(r as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
+	}
+	// Storage: ProcessValidation ProcessModel (r:1 w:1)
+	// Storage: ProcessValidation VersionModel (r:1 w:0)
+	fn disable_process() -> Weight {
+		Weight::from_ref_time(33_000_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
+	}
 }
 
 impl WeightInfo for () {

--- a/pallets/simple-nft/src/benchmarking.rs
+++ b/pallets/simple-nft/src/benchmarking.rs
@@ -5,7 +5,7 @@ use super::*;
 
 use core::convert::TryInto;
 use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite};
-use frame_support::BoundedBTreeMap;
+use frame_support::{BoundedBTreeMap, BoundedVec};
 use frame_system::RawOrigin;
 use sp_std::vec::Vec;
 
@@ -110,7 +110,6 @@ benchmarks! {
   run_process {
     let i in 1..10;
     let o in 1..10;
-
 
     add_nfts::<T>(i)?;
     let inputs = mk_inputs::<T>(i)?;

--- a/pallets/simple-nft/src/benchmarking.rs
+++ b/pallets/simple-nft/src/benchmarking.rs
@@ -5,7 +5,7 @@ use super::*;
 
 use core::convert::TryInto;
 use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite};
-use frame_support::{BoundedBTreeMap, BoundedVec};
+use frame_support::BoundedBTreeMap;
 use frame_system::RawOrigin;
 use sp_std::vec::Vec;
 
@@ -110,6 +110,7 @@ benchmarks! {
   run_process {
     let i in 1..10;
     let o in 1..10;
+
 
     add_nfts::<T>(i)?;
     let inputs = mk_inputs::<T>(i)?;

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -11,8 +11,12 @@ repository = "https://github.com/digicatapult/dscp-node/"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [
+    "derive",
+] }
+scale-info = { version = "2.1.1", default-features = false, features = [
+    "derive",
+] }
 
 pallet-aura = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.30" }
 pallet-balances = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.30" }
@@ -26,10 +30,10 @@ pallet-timestamp = { version = "4.0.0-dev", default-features = false, git = "htt
 pallet-transaction-payment-rpc-runtime-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.30" }
 frame-executive = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.30" }
 sp-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.30" }
-sp-block-builder = {  version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.30"}
+sp-block-builder = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.30" }
 sp-consensus-aura = { version = "0.10.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.30" }
 sp-core = { version = "6.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.30" }
-sp-inherents = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.30"}
+sp-inherents = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.30" }
 sp-offchain = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.30" }
 sp-runtime = { version = "6.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.30" }
 sp-session = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.30" }
@@ -122,24 +126,24 @@ runtime-benchmarks = [
     "sp-runtime/runtime-benchmarks",
 ]
 try-runtime = [
-	"frame-try-runtime",
-	"frame-executive/try-runtime",
-	"frame-system/try-runtime",
+    "frame-try-runtime",
+    "frame-executive/try-runtime",
+    "frame-system/try-runtime",
     "frame-support/try-runtime",
-	"pallet-aura/try-runtime",
-	"pallet-balances/try-runtime",
+    "pallet-aura/try-runtime",
+    "pallet-balances/try-runtime",
     "pallet-collective/try-runtime",
-	"pallet-doas/try-runtime",
-	"pallet-grandpa/try-runtime",
+    "pallet-doas/try-runtime",
+    "pallet-grandpa/try-runtime",
     "pallet-membership/try-runtime",
     "pallet-node-authorization/try-runtime",
     "pallet-preimage/try-runtime",
-	"pallet-process-validation/try-runtime",
-	"pallet-randomness-collective-flip/try-runtime",
+    "pallet-process-validation/try-runtime",
+    "pallet-randomness-collective-flip/try-runtime",
     "pallet-scheduler/try-runtime",
-	"pallet-simple-nft/try-runtime",
-	"pallet-sudo/try-runtime",
-	"pallet-symmetric-key/try-runtime",
-	"pallet-timestamp/try-runtime",
-	"pallet-transaction-payment-free/try-runtime",
+    "pallet-simple-nft/try-runtime",
+    "pallet-sudo/try-runtime",
+    "pallet-symmetric-key/try-runtime",
+    "pallet-timestamp/try-runtime",
+    "pallet-transaction-payment-free/try-runtime",
 ]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -119,6 +119,7 @@ runtime-benchmarks = [
     "pallet-simple-nft/runtime-benchmarks",
     "pallet-symmetric-key/runtime-benchmarks",
     "sp-runtime/runtime-benchmarks",
+    "pallet-process-validation/runtime-benchmarks",
 ]
 try-runtime = [
 	"frame-try-runtime",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -118,8 +118,8 @@ runtime-benchmarks = [
     "pallet-scheduler/runtime-benchmarks",
     "pallet-simple-nft/runtime-benchmarks",
     "pallet-symmetric-key/runtime-benchmarks",
-    "sp-runtime/runtime-benchmarks",
     "pallet-process-validation/runtime-benchmarks",
+    "sp-runtime/runtime-benchmarks",
 ]
 try-runtime = [
 	"frame-try-runtime",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dscp-node-runtime"
-version = "4.4.0"
+version = "4.4.2"
 authors = ["Digital Catapult <https://www.digicatapult.org.uk>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -504,6 +504,7 @@ mod benches {
         [pallet_grandpa, Grandpa]
         [pallet_balances, Balances]
         [pallet_simple_nft, SimpleNFT]
+        [pallet_process_validation, ProcessValidation]
         [pallet_scheduler, Scheduler]
         [pallet_symmetric_key, IpfsKey]
     );

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -384,7 +384,7 @@ impl pallet_process_validation::Config for Runtime {
     type TokenMetadataKey = TokenMetadataKey;
     type TokenMetadataValue = TokenMetadataValue;
     type TokenMetadataValueDiscriminator = MetadataValueType;
-    type MaxProcessProgramLength = ConstU32<200>;
+    type MaxProcessProgramLength = ConstU32<201>;
 }
 
 parameter_types! {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -97,7 +97,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("dscp"),
     impl_name: create_runtime_str!("dscp"),
     authoring_version: 1,
-    spec_version: 440,
+    spec_version: 442,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
Benchmarks for:

1. `create_process`
    - iterate over number of program input
    - maximum length is ~~200~~ 201 of restrictions + boolean ops (length is always odd)

2. `disable_process`

Weights generated and attatched to extrinsics