### PR TITLE
Stop prerelease builds being tagged as latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,7 +154,7 @@ jobs:
             ${{ runner.temp }}/artefacts/dscp-node-${{ needs.get-version.outputs.version }}-x86_64-unknown-linux-gnu.tar.gz
             ${{ runner.temp }}/artefacts/dscp-node-${{ needs.get-version.outputs.version }}-runtime-wasm.tar.gz
 
-  # Docker build  are always performed but are only version tagged on new version
+  # Docker build are always performed but are only version tagged on new version
   build-docker:
     name: Build Docker
     runs-on: ubuntu-latest

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-node",
-  "version": "4.4.2",
+  "version": "4.4.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-node",
-      "version": "4.4.2",
+      "version": "4.4.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^8.11.3"

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-node",
-  "version": "4.4.2",
+  "version": "4.4.3",
   "description": "DSCP node types",
   "repository": {
     "type": "git",

--- a/helm/dscp-node/Chart.yaml
+++ b/helm/dscp-node/Chart.yaml
@@ -6,5 +6,5 @@ maintainers:
     url: www.digicatapult.org.uk
 description: A Helm chart to deploy DSCP nodes
 type: application
-version: 4.4.2
-appVersion: '4.4.2'
+version: 4.4.3
+appVersion: '4.4.3'

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -6,7 +6,7 @@ edition = '2021'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/dscp-node/'
 name = 'dscp-node'
-version = '4.4.2'
+version = '4.4.3'
 
 [[bin]]
 name = 'dscp-node'
@@ -61,7 +61,7 @@ frame-benchmarking = { version = "4.0.0-dev", git = "https://github.com/parityte
 frame-benchmarking-cli = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.30" }
 
 # Local Dependencies
-dscp-node-runtime = { path = '../runtime', version = '4.4.2' }
+dscp-node-runtime = { path = '../runtime', version = '4.4.3' }
 
 # CLI-specific dependencies
 try-runtime-cli = { version = "0.10.0-dev", optional = true, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.30" }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dscp-node-runtime"
-version = "4.4.2"
+version = "4.4.3"
 authors = ["Digital Catapult <https://www.digicatapult.org.uk>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -97,7 +97,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("dscp"),
     impl_name: create_runtime_str!("dscp"),
     authoring_version: 1,
-    spec_version: 442,
+    spec_version: 443,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/scripts/check-version.sh
+++ b/scripts/check-version.sh
@@ -90,7 +90,7 @@ else
 fi
 
 if [ $IS_PRERELEASE ]; then
-  echo "IS_NEW_VERSION=true" >> $GITHUB_OUTPUT
+  echo "IS_PRERELEASE=true" >> $GITHUB_OUTPUT
 else
-  echo "IS_NEW_VERSION=false" >> $GITHUB_OUTPUT
+  echo "IS_PRERELEASE=false" >> $GITHUB_OUTPUT
 fi


### PR DESCRIPTION
Fix a mistake in #92 that's causing prerelease builds to be set as `latest` rather than `prerelease`