### PR TITLE
Upgrade Substrate Document

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,6 @@ There are several files in the `node` directory - take special note of the follo
   [GRANDPA](https://substrate.dev/docs/en/knowledgebase/advanced/consensus#grandpa) finality
   gadget.
 
-  [Updrading Node](Upgrade.md)
 
 ### Runtime
 

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ There are several files in the `node` directory - take special note of the follo
   [GRANDPA](https://substrate.dev/docs/en/knowledgebase/advanced/consensus#grandpa) finality
   gadget.
 
-  [Updarading Node](Upgrade.md)
+  [Updrading Node](Upgrade.md)
 
 ### Runtime
 

--- a/README.md
+++ b/README.md
@@ -315,6 +315,8 @@ There are several files in the `node` directory - take special note of the follo
   [GRANDPA](https://substrate.dev/docs/en/knowledgebase/advanced/consensus#grandpa) finality
   gadget.
 
+  [Updarading Node](Upgrade.md)
+
 ### Runtime
 
 In Substrate, the terms

--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ Then you can run the benchmark tool with for example
 
 The generated weights implementation should then be integrated into the `pallet_simple_nft` module.
 
+### Upgrading Substrate
+
+We aim to keep our substrate codebase in lockstep with the latest released `Polkadot-v<version>` branches on the [Parity Substrate](https://github.com/paritytech/substrate) repository.
+
+See our upgrade documentation [here](./Upgrade.md)
+
 ### Run in Docker
 
 First, install [Docker](https://docs.docker.com/get-docker/) and
@@ -314,7 +320,6 @@ There are several files in the `node` directory - take special note of the follo
   mechanism and the
   [GRANDPA](https://substrate.dev/docs/en/knowledgebase/advanced/consensus#grandpa) finality
   gadget.
-
 
 ### Runtime
 

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -1,4 +1,4 @@
-# Upgrading Substrate Dependencies
+# Description
 
 This guide will hopefully help upgrade Substrate in the future.
 
@@ -14,7 +14,7 @@ You will need to run `rustup` which is [documented here](https://github.com/digi
 
 # Upgrade Substrate
 
-This [tool](https://crates.io/crates/diener) can be used to update the version fairlessly painlesslly.
+This [diener tool](https://crates.io/crates/diener) can be used to update the file versions fairly painlesslly.
 
 After the version updates have been made, depending on the length of time between version releases, there may be a **lot** of changes.
 
@@ -32,7 +32,7 @@ To build the Node:
 cargo build --release
 ```
 
-# Code Changes
+# Pallets
 
 [Version changes can be the most difficult parts of the code](https://github.com/digicatapult/dscp-node/pull/91/files#diff-6d40c1b90e071cdb5271cce23374b2ecae20ab264980fda18a4d4d4c290efca1), if you look at the original compared against the new version there could substancial changes (depending on the update).
 
@@ -40,7 +40,7 @@ After the change each pallet needs to be inspected, fixed if needed, along with 
 
 Once a pallet has been brought up to date it needs to be tested, something like `cargo test -p pallet-transaction-payment-free`, of course change the pallet name to what is necessary. If it passes push it and potentially into it's own PR into the **integration**. If there are errors Rust is very good at highlighting issues and suggesting looking error codes `rustc --explain E0152 `.
 
-## DSCP-Node
+## Runtime
 
 The final step is to update the dscp-node. There are several steps to do now, the dscp-node version must be changed and then and then complete the tests and check runtime-benchmarks builds. And in the Runtime file lib.rs file, roughly line 100, the version must be changed there as a set of numbers, so instead of `5.6.8` it would be `568`, for example `spec_version: 444`
 

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -12,21 +12,23 @@ You will need to run `rustup` which is [documented here](https://github.com/digi
 
 ## Upgrade Substrate
 
-This [diener tool](https://crates.io/crates/diener) (which needs to be in the dependencies) can be used to update the toml versions easily by upgrading each `cargo.toml` given a specific branch/path.
+This [diener tool](https://crates.io/crates/diener) can be used to update the toml versions easily by upgrading each `cargo.toml` given a specific branch/path
 
+`cargo install diener`
+and in the root of the `dscp-node` directory run `diener update --substrate --branch polkadot-v0.9.30`
 ## Build the Node
 
 To build the Node:
 
 ```bash
-cargo build --release
+cargo build --release --features runtime-benchmarks
 ```
 
 ## Pallets
 
-After the version updates have been made, depending on the length of time between version releases, there may be a **lot** of changes.
+Once the version updates have been made we should try to build a pallet, in this example we shall try to build the `pallet-doas` in isolation.
 
-If a file has errors run `cargo check` and it will only check that one file.
+`cargo build --release -p pallet-doas`
 
 If there are errors you will need to investigate. It would also be worth looking at the [substrate-node-template](https://github.com/substrate-developer-hub/substrate-node-template) to see what what changes they have made when updgrading and potentially compare code changes between different tagged releases of substrate.
 
@@ -36,25 +38,36 @@ obtained from checking the [Polkadot `0.9.30` branch](https://github.com/parityt
 
 [Version changes can be the most difficult parts of the code](https://github.com/digicatapult/dscp-node/pull/91/files#diff-6d40c1b90e071cdb5271cce23374b2ecae20ab264980fda18a4d4d4c290efca1), if you look at the original compared against the new version there could substancial, or minor, changes (depending on the update).
 
-After the change each pallet needs to be inspected, fixed if needed, along with fixes to tests, ensuring the runtime-benchmarks feature build.
+After the change each pallet needs to be inspected, fixed if needed, along with fixes to tests.   If there are any compilation errors Rust is very good at highlighting issues and suggesting looking error codes e.g. `rustc --explain E0152 `.
 
 ```bash
-cargo build --release --features runtime-benchmarks
+cargo build --release pallet-doas
 ```
 
-Once a pallet has been brought up to date it needs to be tested, something like `cargo test -p pallet-transaction-payment-free`, of course change the pallet name to the pallet you are on. If it passes, push it into it's own PR, then into the **integration**. If there are errors Rust is very good at highlighting issues and suggesting looking error codes `rustc --explain E0152 `.
+Once a pallet has been brought up to date it needs to be tested, something like 
+`cargo test -p pallet-doas`
+
+If it passes, bump its version in the pallets `pallets/doas/Cargo.toml` push it into it's own PR, then into the **integration** branch
 
 ## Runtime
 
-In the Runtime file, lib.rs, the `spec_version` must be changed to a set of numbers formatted as three digits rather than `5.6.8`, so instead of `5.6.8` it would be `568`, for example `spec_version: 444`.
+We now need to test that the upgraded dependencies work for the runtime including our newly upgraded pallets.  So firstly replace all the pallet versions in the runtime's `runtime/Cargo.toml` and then we need to test a runtime build, we do this by
+`cargo build --release -p dscp-node-runtime`
+
+We will need to increment the runtimes `spec_version` to a higher value, note spec_version does not recognize semver, so we treat it as a whole number. e.g. In place of `5.6.8` the `spec_version` would be `568`.
+
+We should also bump our runtime's version in `runtime/Cargo.toml`
+We should now run the tests for the runtime, which we can do using:
+
+`cargo test --release -p dscp-node-runtime`
 
 If the tests pass create a PR from the **integration** branch.
 
 ## Node
 
-The last stop in the node section is to update the dscp-node.
+The last item to upgrade is the `dscp-node` itself.
 
-There are two steps to undertake, the dscp-node version must be changed and then and then completion of the tests. If this passes then check runtime-benchmarks builds.
+There are two steps to undertake, the dscp-node's and dscp-node-runtime's versions should be bumped in `node/Cargo.toml`  and then  we should try to build with the runtime-benchmarks feature enabled.
 
 ```bash
 cargo build --release --features runtime-benchmarks

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -48,7 +48,7 @@ cargo build --release pallet-doas
 ```
 
 Once a pallet has been brought up to date it needs to be tested, something like
-`cargo test -p pallet-doas`
+`cargo test --release -p pallet-doas`
 
 If it passes, bump its version in the pallets `pallets/doas/Cargo.toml` push it into it's own PR, then into the **integration** branch
 

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -4,7 +4,7 @@ This guide will hopefully help upgrade Substrate in the future.
 
 This is a guide based on updating from `0.9.25` to `0.9.30` and the issues it caused can be seen [here](https://github.com/digicatapult/dscp-node/pull/91/files)
 
-# First Thing
+# Prerequisities
 
 Create an **integration** branch which all other branches will be PR'd into. This reduces git issues like having to use `git reset`.
 

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -42,7 +42,7 @@ Once a pallet has been brought up to date it needs to be tested, something like 
 
 ## DSCP-Node
 
-The final node to look at is the dscp-node. There are several steps to do now, the dscp-node version must be changed and then and then complete the tests and check runtime-benchmarks builds. And in the Runtime file, roughly line 100, the version must be changed there as a set of numbers, so instead of `5.6.8` it would be `568`, for eaxmple `spec_version: 444`
+The final node to look at is the dscp-node. There are several steps to do now, the dscp-node version must be changed and then and then complete the tests and check runtime-benchmarks builds. And in the Runtime file, roughly line 100, the version must be changed there as a set of numbers, so instead of `5.6.8` it would be `568`, for example `spec_version: 444`
 
 If the tests pass create a PR from the **integration** branch.
 

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -2,29 +2,13 @@
 
 This guide will hopefull help in the future when it comes to upgrading Substrate.
 
-This is a case study of updating from `0.9.25` to `0.9.30` and the issues it caused can be seen [here](https://github.com/digicatapult/dscp-node/pull/91/files)
+This is a guide based o updating from `0.9.25` to `0.9.30` and the issues it caused can be seen [here](https://github.com/digicatapult/dscp-node/pull/91/files)
 
 # First Thing
 
-Make sure you have pulled the main branch. Then, as Dave advised, checkout a integration branch, this branch is where all other project branches will be merged, **NOT INTO MAIN**. Matt said "that will break up the reviews and make the changes more understandable...and it provides a point of integration so we’re not doing weird `git reset` commands or the like".
+You will need to run `rustup` which is [documented here](https://github.com/digicatapult/dscp-node/blob/main/README.md).
 
-# Rustup
-
-You'll need rustup up so run:
-
-    ```bash
-    curl https://sh.rustup.rs -sSf | sh
-    ```
-
-The you'll need the scripts:
-
-    ```bash
-    ./scripts/init.sh
-    ```
-
-First search for the version you want to change (search/replace), then replace it with the version you require.
-
-After making the changes build the repo
+Then build the Node:
 
 ```bash
 cargo build --release

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -12,7 +12,7 @@ You will need to run `rustup` which is [documented here](https://github.com/digi
 
 # Upgrade Substrate
 
-This [diener tool](https://crates.io/crates/diener) can be used to update the file versions fairly painlesslly by upgrading each `cargo.toml` given a specific branch/path.
+This [diener tool](https://crates.io/crates/diener) can be used to update the `toml` versions fairly painlesslly by upgrading each `cargo.toml` given a specific branch/path.
 
 # Build the Node
 

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -36,7 +36,7 @@ For example, during the `0.9.30` upgrade `Event` and `Origin` became `RuntimeEve
 `RuntimeOrigin`. This information was
 obtained from checking the [Polkadot `0.9.30` branch](https://github.com/paritytech/substrate/tree/polkadot-v0.9.31). Checking the branch will help with renaming and syntax changes.
 
-For example:
+There can calso be code changes, these will need to be researchded,for example:
 
 ```rust
     let doas_root_unchecked_weight_call = DoasCall::doas_root_unchecked_weight { call, weight: 1_000 }

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -1,3 +1,16 @@
+##Code Changes
+...
+
+### Pallets
+
+...
+
+### Runtime
+
+...
+
+### Node
+
 # Description
 
 This guide will hopefully help upgrade Substrate in the future.
@@ -40,9 +53,13 @@ After the change each pallet needs to be inspected, fixed if needed, along with 
 
 Once a pallet has been brought up to date it needs to be tested, something like `cargo test -p pallet-transaction-payment-free`, of course change the pallet name to what is necessary. If it passes push it and potentially into it's own PR into the **integration**. If there are errors Rust is very good at highlighting issues and suggesting looking error codes `rustc --explain E0152 `.
 
+## Node
+
+The final step is to update the dscp-node. There are several steps to do now, the dscp-node version must be changed and then and then complete the tests and check runtime-benchmarks builds.
+
 ## Runtime
 
-The final step is to update the dscp-node. There are several steps to do now, the dscp-node version must be changed and then and then complete the tests and check runtime-benchmarks builds. And in the Runtime file lib.rs file, roughly line 100, the version must be changed there as a set of numbers, so instead of `5.6.8` it would be `568`, for example `spec_version: 444`
+And in the Runtime file lib.rs file, roughly line 100, the version must be changed there as a set of numbers, so instead of `5.6.8` it would be `568`, for example `spec_version: 444`
 
 If the tests pass create a PR from the **integration** branch.
 

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -16,7 +16,9 @@ Then build the Node:
 cargo build --release
 ```
 
-After this has built, depending on the length of time between version releases there may be a **lot** of changes.
+This [tool](https://crates.io/crates/diener) can be used to update the version.
+
+After the changes have been made, depending on the length of time between version releases, there may be a **lot** of changes.
 
 If there are errors you will need to investigate, some may be obvious but it will also be useful to look at the latest version of the branch or use any documentation if available.
 

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -38,7 +38,7 @@ obtained from checking the [Polkadot `0.9.30` branch](https://github.com/parityt
 
 # Code Changes
 
-There can calso be code changes, these will need to be researchded,for example:
+There can also be code changes, these will need to be researchded,for example:
 
 ```rust
     let doas_root_unchecked_weight_call = DoasCall::doas_root_unchecked_weight { call, weight: 1_000 }

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -42,11 +42,13 @@ Once a pallet has been brought up to date it needs to be tested, something like 
 
 ## Node
 
-The final step is to update the dscp-node. There are several steps to do now, the dscp-node version must be changed and then and then complete the tests and check runtime-benchmarks builds.
+The last stop in the node section is to update the dscp-node.
+
+There are several steps to do now, the dscp-node version must be changed and then and then complete the tests and check runtime-benchmarks builds.
 
 ## Runtime
 
-And in the Runtime file lib.rs file, roughly line 100, the version must be changed there as a set of numbers, so instead of `5.6.8` it would be `568`, for example `spec_version: 444`
+Inn the Runtime file, lib.rs, roughly line 100, the version must be changed there as a set of numbers, so instead of `5.6.8` it would be `568`, for example `spec_version: 444`
 
 If the tests pass create a PR from the **integration** branch.
 

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -8,7 +8,7 @@ This is a guide based on updating from `0.9.25` to `0.9.30` and the issues it ca
 
 Create an **integration** branch which all other branches will be PR'd into. This reduces git issues like having to use `git reset`.
 
-upgrade the references to the [paritytech/substrate](https://github.com/paritytech/substrate) repo in each of the wrokspaces cargo.toml files. By doing this it will ensure that the `cargo build` (as seen below) works and the rest of the process can take place.
+Upgrade the references to the [paritytech/substrate](https://github.com/paritytech/substrate) repo in each of the workspace cargo.toml files. Doing this it will help ensure that the `cargo build` (as seen below) works and the rest of the process can take place.
 
 You will need to run `rustup` which is [documented here](https://github.com/digicatapult/dscp-node/blob/main/README.md).
 
@@ -18,7 +18,7 @@ This [tool](https://crates.io/crates/diener) can be used to update the version f
 
 After the version updates have been made, depending on the length of time between version releases, there may be a **lot** of changes.
 
-If there are errors you will need to investigate, some may be obvious but it will also be useful to look at the latest version of the branch or use any documentation if available.
+If there are errors you will need to investigate, some may be obvious but it will also be useful to look at the latest version of the branch or use any documentation if available. It may also be worth looking at the [substrate-node-template](https://github.com/substrate-developer-hub/substrate-node-template) to see what what changes they have made when updgrading.
 
 For example, during the `0.9.31` upgrade `Event` and `Origin` became `RuntimeEvent` and
 `RuntimeOrigin`. This information was

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -30,7 +30,7 @@ If there are errors you will need to investigate, some may be obvious but it wil
 
 For example, during the `0.9.30` upgrade `Event` and `Origin` became `RuntimeEvent` and
 `RuntimeOrigin`. This information was
-obtained from checking the [Polkadot `0.9.30` branch](https://github.com/paritytech/substrate/tree/polkadot-v0.9.31). Checking the branch will help with renaming and syntax changes.
+obtained from checking the [Polkadot `0.9.30` branch](https://github.com/paritytech/substrate/tree/polkadot-v0.9.30). Checking the branch will help with renaming and syntax changes.
 
 # Code Change Example
 

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -53,7 +53,7 @@ let doas_root_unchecked_weight_call = DoasCall::doas_root_unchecked_weight {
 
 After the change each pallet needs to be inspected, fixed if needed, along with fixes to tests and ensuring the runtime-benchmarks feature build.
 
-Once a pallet has been brought up to date it needs to be tested, something like `cargo test -p pallet-transaction-payment-free`, of course change the pallet name to what is necessary. If it passes push it and potentially into it's own PR into the **integration**.
+Once a pallet has been brought up to date it needs to be tested, something like `cargo test -p pallet-transaction-payment-free`, of course change the pallet name to what is necessary. If it passes push it and potentially into it's own PR into the **integration**. If there are errors Rust is very good at highlighting issues and suggesting looking error codes `rustc --explain E0152 `.
 
 ## DSCP-Node
 

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -28,7 +28,7 @@ obtained from checking the [Polkadot `0.9.30` branch](https://github.com/parityt
 
 # Code Changes
 
-There can also be code changes, these will need to be researchded,for example:
+Here is an example of a code change, some will be relatively minor:
 
 ```rust
     let doas_root_unchecked_weight_call = DoasCall::doas_root_unchecked_weight { call, weight: 1_000 }

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -32,7 +32,7 @@ For example, during the `0.9.30` upgrade `Event` and `Origin` became `RuntimeEve
 `RuntimeOrigin`. This information was
 obtained from checking the [Polkadot `0.9.30` branch](https://github.com/paritytech/substrate/tree/polkadot-v0.9.31). Checking the branch will help with renaming and syntax changes.
 
-# Code Changes
+# Code Change Example
 
 This code requires a change to the parameter:
 

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -42,7 +42,7 @@ Once a pallet has been brought up to date it needs to be tested, something like 
 
 ## DSCP-Node
 
-The final node to look at is the dscp-node. There are several steps to do now, the dscp-node version must be changed and then and then complete the tests and check runtime-benchmarks builds. And in the Runtime file lib.rs file, roughly line 100, the version must be changed there as a set of numbers, so instead of `5.6.8` it would be `568`, for example `spec_version: 444`
+The final step is to update the dscp-node. There are several steps to do now, the dscp-node version must be changed and then and then complete the tests and check runtime-benchmarks builds. And in the Runtime file lib.rs file, roughly line 100, the version must be changed there as a set of numbers, so instead of `5.6.8` it would be `568`, for example `spec_version: 444`
 
 If the tests pass create a PR from the **integration** branch.
 

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -20,7 +20,7 @@ After the version updates have been made, depending on the length of time betwee
 
 If there are errors you will need to investigate, some may be obvious but it will also be useful to look at the latest version of the branch or use any documentation if available. It may also be worth looking at the [substrate-node-template](https://github.com/substrate-developer-hub/substrate-node-template) to see what what changes they have made when updgrading.
 
-For example, during the `0.9.31` upgrade `Event` and `Origin` became `RuntimeEvent` and
+For example, during the `0.9.30` upgrade `Event` and `Origin` became `RuntimeEvent` and
 `RuntimeOrigin`. This information was
 obtained from checking the [Polkadot `0.9.31` branch](https://github.com/paritytech/substrate/tree/polkadot-v0.9.31). Checking the branch will help with renaming and syntax changes.
 

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -42,7 +42,7 @@ Once a pallet has been brought up to date it needs to be tested, something like 
 
 ## DSCP-Node
 
-The final node to look at is the dscp-node. There are several steps to do now, the dscp-node version must be changed and then and then complete the tests and check runtime-benchmarks builds. And in the Runtime file, roughly line 100, the version must be changed there as a set of numbers, so instead of `5.6.8` it would be `568`
+The final node to look at is the dscp-node. There are several steps to do now, the dscp-node version must be changed and then and then complete the tests and check runtime-benchmarks builds. And in the Runtime file, roughly line 100, the version must be changed there as a set of numbers, so instead of `5.6.8` it would be `568`, for eaxmple `spec_version: 444`
 
 If the tests pass create a PR from the **integration** branch.
 

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -15,7 +15,8 @@ You will need to run `rustup` which is [documented here](https://github.com/digi
 This [diener tool](https://crates.io/crates/diener) can be used to update the toml versions easily by upgrading each `cargo.toml` given a specific branch/path
 
 `cargo install diener`
-and in the root of the `dscp-node` directory run `diener update --substrate --branch polkadot-v0.9.30`
+and in the root of the `dscp-node` directory run `diener update --substrate --branch polkadot-v0.9.{version}`
+
 ### Test Building the Node
 
 To build the Node:
@@ -38,20 +39,20 @@ obtained from checking the [Polkadot `0.9.30` branch](https://github.com/parityt
 
 [Version changes can be the most difficult parts of the code](https://github.com/digicatapult/dscp-node/pull/91/files#diff-6d40c1b90e071cdb5271cce23374b2ecae20ab264980fda18a4d4d4c290efca1), if you look at the original compared against the new version there could substancial, or minor, changes (depending on the update).
 
-After the change each pallet needs to be inspected, fixed if needed, along with fixes to tests.   If there are any compilation errors Rust is very good at highlighting issues and suggesting looking error codes e.g. `rustc --explain E0152 `.
+After the change each pallet needs to be inspected, fixed if needed, along with fixes to tests. If there are any compilation errors Rust is very good at highlighting issues and suggesting looking error codes e.g. `rustc --explain E0152 `.
 
 ```bash
 cargo build --release pallet-doas
 ```
 
-Once a pallet has been brought up to date it needs to be tested, something like 
+Once a pallet has been brought up to date it needs to be tested, something like
 `cargo test -p pallet-doas`
 
 If it passes, bump its version in the pallets `pallets/doas/Cargo.toml` push it into it's own PR, then into the **integration** branch
 
 ### Runtime
 
-We now need to test that the upgraded dependencies work for the runtime including our newly upgraded pallets.  So firstly replace all the pallet versions in the runtime's `runtime/Cargo.toml` and then we need to test a runtime build, we do this by
+We now need to test that the upgraded dependencies work for the runtime including our newly upgraded pallets. So firstly replace all the pallet versions in the runtime's `runtime/Cargo.toml` and then we need to test a runtime build, we do this by
 `cargo build --release -p dscp-node-runtime`
 
 We will need to increment the runtimes `spec_version` to a higher value, note spec_version does not recognize semver, so we treat it as a whole number. e.g. In place of `5.6.8` the `spec_version` would be `568`.
@@ -67,7 +68,7 @@ If the tests pass create a PR from the **integration** branch.
 
 The last item to upgrade is the `dscp-node` itself.
 
-There are two steps to undertake, the dscp-node's and dscp-node-runtime's versions should be bumped in `node/Cargo.toml`  and then  we should try to build with the runtime-benchmarks feature enabled.
+There are two steps to undertake, the dscp-node's and dscp-node-runtime's versions should be bumped in `node/Cargo.toml` and then we should try to build with the runtime-benchmarks feature enabled.
 
 ```bash
 cargo build --release --features runtime-benchmarks

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -14,14 +14,6 @@ You will need to run `rustup` which is [documented here](https://github.com/digi
 
 This [diener tool](https://crates.io/crates/diener) can be used to update the file versions fairly painlesslly by upgrading each `cargo.toml` given a specific branch/path.
 
-After the version updates have been made, depending on the length of time between version releases, there may be a **lot** of changes.
-
-If there are errors you will need to investigate, some may be obvious but it will also be useful to look at the latest version of the branch or use any documentation if available. It may also be worth looking at the [substrate-node-template](https://github.com/substrate-developer-hub/substrate-node-template) to see what what changes they have made when updgrading.
-
-For example, during the `0.9.30` upgrade `Event` and `Origin` became `RuntimeEvent` and
-`RuntimeOrigin`. This information was
-obtained from checking the [Polkadot `0.9.30` branch](https://github.com/paritytech/substrate/tree/polkadot-v0.9.30). Checking the branch will help with renaming and syntax changes.
-
 # Build the Node
 
 To build the Node:
@@ -29,6 +21,14 @@ To build the Node:
 ```bash
 cargo build --release
 ```
+
+After the version updates have been made, depending on the length of time between version releases, there may be a **lot** of changes.
+
+If there are errors you will need to investigate, some may be obvious but it will also be useful to look at the latest version of the branch or use any documentation if available. It may also be worth looking at the [substrate-node-template](https://github.com/substrate-developer-hub/substrate-node-template) to see what what changes they have made when updgrading.
+
+For example, during the `0.9.30` upgrade `Event` and `Origin` became `RuntimeEvent` and
+`RuntimeOrigin`. This information was
+obtained from checking the [Polkadot `0.9.30` branch](https://github.com/paritytech/substrate/tree/polkadot-v0.9.30). Checking the branch will help with renaming and syntax changes.
 
 # Pallets
 

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -26,6 +26,8 @@ cargo build --release
 
 After the version updates have been made, depending on the length of time between version releases, there may be a **lot** of changes.
 
+If a file has errors run `cargo check` and it will only check that one file.
+
 If there are errors you will need to investigate, some may be obvious but it will also be useful to look at the latest version of the branch or use any documentation if available. It may also be worth looking at the [substrate-node-template](https://github.com/substrate-developer-hub/substrate-node-template) to see what what changes they have made when updgrading.
 
 For example, during the `0.9.30` upgrade `Event` and `Origin` became `RuntimeEvent` and

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -15,7 +15,7 @@ You will need to run `rustup` which is [documented here](https://github.com/digi
 This [diener tool](https://crates.io/crates/diener) can be used to update the toml versions easily by upgrading each `cargo.toml` given a specific branch/path
 
 `cargo install diener`
-and in the root of the `dscp-node` directory run `diener update --substrate --branch polkadot-v0.9.<var>`
+and in the root of the `dscp-node` directory run `diener update --substrate --branch polkadot-v<version>`
 
 ### Test Building the Node
 

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -53,7 +53,7 @@ let doas_root_unchecked_weight_call = DoasCall::doas_root_unchecked_weight {
 
 [Version changes can be the most difficult parts of the code](https://github.com/digicatapult/dscp-node/pull/91/files#diff-6d40c1b90e071cdb5271cce23374b2ecae20ab264980fda18a4d4d4c290efca1), if you look at the original compared against the new version there could substancial changes (depending on the update).
 
-After the change each pallet needs to be inspected, fixed if needed along with fixes to tests and ensuring the runtime-benchmarks feature build.
+After the change each pallet needs to be inspected, fixed if needed, along with fixes to tests and ensuring the runtime-benchmarks feature build.
 
 Once a pallet is working it should be put into it's own PR into the **integration**.
 

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -57,8 +57,8 @@ Once a pallet is working it should be put into it's own PR into the **integratio
 
 ## DSCP-Node
 
-The final pallet to look at is the dscp-node. The first thing to do is update the dscp-node and then follow the previous tests from the other pallets and check runtime-benchmarks builds.
+The final node to look at is the dscp-node. The first thing to do is update the dscp-node and then and then complete the tests and check runtime-benchmarks builds.
 
 If the tests pass create a PR from the **integration** branch.
 
-Once all of the pallets have been checked and pass their tests a PR can be raised against the **integration** branch into main.
+Once all of the nodes/pallets have been checked and pass their tests a PR can be raised against the **integration** branch into main.

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -36,6 +36,8 @@ For example, during the `0.9.30` upgrade `Event` and `Origin` became `RuntimeEve
 `RuntimeOrigin`. This information was
 obtained from checking the [Polkadot `0.9.30` branch](https://github.com/paritytech/substrate/tree/polkadot-v0.9.31). Checking the branch will help with renaming and syntax changes.
 
+# Code Changes
+
 There can calso be code changes, these will need to be researchded,for example:
 
 ```rust

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -42,7 +42,7 @@ Once a pallet has been bought up to date it needs to be tested, something like `
 
 ## Runtime
 
-In the Runtime file, lib.rs the version must be changed there as a set of numbers, so instead of `5.6.8` it would be `568`, for example `spec_version: 444`
+In the Runtime file, lib.rs, the `spec_version` must be changed to a set of numbers formatted as three digits rather than `5.6.8`, so instead of `5.6.8` it would be `568`, for example `spec_version: 444`.
 
 If the tests pass create a PR from the **integration** branch.
 

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -32,22 +32,7 @@ To build the Node:
 cargo build --release
 ```
 
-# Code Change Example
-
-This code requires a change to the parameter:
-
-```rust
-    let doas_root_unchecked_weight_call = DoasCall::doas_root_unchecked_weight { call, weight: 1_000 }
-```
-
-Becomes:
-
-```rust
-let doas_root_unchecked_weight_call = DoasCall::doas_root_unchecked_weight {
-            call,
-            weight: Weight::from_ref_time(1_000)
-        };
-```
+# Code Changes
 
 [Version changes can be the most difficult parts of the code](https://github.com/digicatapult/dscp-node/pull/91/files#diff-6d40c1b90e071cdb5271cce23374b2ecae20ab264980fda18a4d4d4c290efca1), if you look at the original compared against the new version there could substancial changes (depending on the update).
 

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -12,7 +12,7 @@ You will need to run `rustup` which is [documented here](https://github.com/digi
 
 # Upgrade Substrate
 
-This [diener tool](https://crates.io/crates/diener) can be used to update the `cargo.toml` versions fairly painlesslly by upgrading each `cargo.toml` given a specific branch/path.
+This [diener tool](https://crates.io/crates/diener) can be used to update the toml versions fairly painlesslly by upgrading each `cargo.toml` given a specific branch/path.
 
 # Build the Node
 

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -1,12 +1,14 @@
 # Upgrading Substrate Dependencies
 
-This guide will hopefull help in the future when it comes to upgrading Substrate.
+This guide will hopefully help upgrade Substrate in the future.
 
-This is a guide based o updating from `0.9.25` to `0.9.30` and the issues it caused can be seen [here](https://github.com/digicatapult/dscp-node/pull/91/files)
+This is a guide based on updating from `0.9.25` to `0.9.30` and the issues it caused can be seen [here](https://github.com/digicatapult/dscp-node/pull/91/files)
 
 # First Thing
 
 You will need to run `rustup` which is [documented here](https://github.com/digicatapult/dscp-node/blob/main/README.md).
+
+# Build the Node
 
 Then build the Node:
 
@@ -14,9 +16,9 @@ Then build the Node:
 cargo build --release
 ```
 
-Depending on the lenght of time between versions there may be a **lot** of changes.
+Depending on the lenght of time between version leases there may be a **lot** of changes.
 
-If there are errors you will need to investigate, some may be obvious but it might be worth looking at the latest version of the branch or use any documentation if available.
+If there are errors you will need to investigate, some may be obvious but it will also be useful to look at the latest version of the branch or use any documentation if available.
 
 For example, during the `0.9.30` upgrade `Event` and `Origin` became `RuntimeEvent` and
 `RuntimeOrigin`. This information was

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -8,17 +8,9 @@ This is a guide based on updating from `0.9.25` to `0.9.30` and the issues it ca
 
 Create an **integration** branch which all other branches will be PR'd into. This reduces git issues like having to use `git reset`.
 
-Upgrade the references in the repo. By doing this it will ensure that the `cargo build` (as seen below) works and the rest of the process can take place.
+upgrade the references to the [paritytech/substrate](https://github.com/paritytech/substrate) repo in each of the wrokspaces cargo.toml files. By doing this it will ensure that the `cargo build` (as seen below) works and the rest of the process can take place.
 
 You will need to run `rustup` which is [documented here](https://github.com/digicatapult/dscp-node/blob/main/README.md).
-
-# Build the Node
-
-To build the Node:
-
-```bash
-cargo build --release
-```
 
 # Upgrade Substrate
 
@@ -31,6 +23,14 @@ If there are errors you will need to investigate, some may be obvious but it wil
 For example, during the `0.9.31` upgrade `Event` and `Origin` became `RuntimeEvent` and
 `RuntimeOrigin`. This information was
 obtained from checking the [Polkadot `0.9.31` branch](https://github.com/paritytech/substrate/tree/polkadot-v0.9.31). Checking the branch will help with renaming and syntax changes.
+
+# Build the Node
+
+To build the Node:
+
+```bash
+cargo build --release
+```
 
 # Code Change Example
 

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -6,19 +6,27 @@ This is a guide based on updating from `0.9.25` to `0.9.30` and the issues it ca
 
 # First Thing
 
+Create an **integration** branch which all other branches will be PR'd into. This reduces git issues like having to use `git reset`.
+
+Upgrade the references in the repo. By doing this it will ensure that the `cargo build` (as seen below) works and the rest of the process can take place.
+
 You will need to run `rustup` which is [documented here](https://github.com/digicatapult/dscp-node/blob/main/README.md).
 
 # Build the Node
 
-Then build the Node:
+To build the Node:
 
 ```bash
 cargo build --release
 ```
 
-This [tool](https://crates.io/crates/diener) can be used to update the version.
+# Upgrade Substrate
 
-After the changes have been made, depending on the length of time between version releases, there may be a **lot** of changes.
+This [tool](https://crates.io/crates/diener) can be used to update the version fairlessly painlesslly.
+
+After the version updates have been made, depending on the length of time between version releases, there may be a **lot** of changes.
+
+Here is a brief example:
 
 If there are errors you will need to investigate, some may be obvious but it will also be useful to look at the latest version of the branch or use any documentation if available.
 
@@ -28,7 +36,7 @@ obtained from checking the [Polkadot `0.9.30` branch](https://github.com/parityt
 
 # Code Changes
 
-Here is an example of a code change, some will be relatively minor:
+This code requires a change to the parameter:
 
 ```rust
     let doas_root_unchecked_weight_call = DoasCall::doas_root_unchecked_weight { call, weight: 1_000 }
@@ -43,4 +51,16 @@ let doas_root_unchecked_weight_call = DoasCall::doas_root_unchecked_weight {
         };
 ```
 
-Perhaps the most [difficult parts are the changes to the code](https://github.com/digicatapult/dscp-node/pull/91/files#diff-6d40c1b90e071cdb5271cce23374b2ecae20ab264980fda18a4d4d4c290efca1L66), if you look at the original compared against the new version there could substancial changes (depending on the update).
+[Version changes can be the most difficult parts of the code](https://github.com/digicatapult/dscp-node/pull/91/files#diff-6d40c1b90e071cdb5271cce23374b2ecae20ab264980fda18a4d4d4c290efca1), if you look at the original compared against the new version there could substancial changes (depending on the update).
+
+After the change each pallet needs to be inspected, fixed if needed along with fixes to tests and ensuring the runtime-benchmarks feature build.
+
+Once a pallet is working it should be put into it's own PR into the **integration**.
+
+## DSCP-Node
+
+The final pallet to look at is the dscp-node. The first thing to do is update the dscp-node and then follow the prebious tests from the other pallets and check runtime-benchmarks builds.
+
+If the tests pass create a PR from the **integration** branch.
+
+Once all of the pallets have been checked and pass their tests a PR can be raised against the **integration** branch into main.

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -1,20 +1,20 @@
-# Description
+## Description
 
 This guide will hopefully provide help to upgrade Substrate in the future.
 
 This is a guide based on updating from `0.9.25` to `0.9.30` and the issues it caused can be seen [here](https://github.com/digicatapult/dscp-node/pull/91/files)
 
-# Prerequisities
+## Prerequisities
 
 Make sure **main** is up to date and create an **integration** branch which all other branches will be PR'd into. This reduces git issues like having to use `git reset`.
 
 You will need to run `rustup` which is [documented here](https://github.com/digicatapult/dscp-node/blob/main/README.md).
 
-# Upgrade Substrate
+## Upgrade Substrate
 
 This [diener tool](https://crates.io/crates/diener) can be used to update the toml versions easily by upgrading each `cargo.toml` given a specific branch/path.
 
-# Build the Node
+## Build the Node
 
 To build the Node:
 
@@ -22,7 +22,7 @@ To build the Node:
 cargo build --release
 ```
 
-# Pallets
+## Pallets
 
 After the version updates have been made, depending on the length of time between version releases, there may be a **lot** of changes.
 

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -19,6 +19,8 @@ and in the root of the `dscp-node` directory run `diener update --substrate --br
 
 ### Test Building the Node
 
+We are test building the Node having only upgraded the dependencies, this includes no code changes to any of the pallets, runtime or node. We include features runtime benchmarks to fully tests all deps.
+
 To build the Node:
 
 ```bash

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -1,4 +1,4 @@
-## Description
+# Description
 
 This guide will hopefully provide help to upgrade Substrate in the future.
 

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -59,7 +59,7 @@ Once a pallet is working it should be put into it's own PR into the **integratio
 
 ## DSCP-Node
 
-The final pallet to look at is the dscp-node. The first thing to do is update the dscp-node and then follow the prebious tests from the other pallets and check runtime-benchmarks builds.
+The final pallet to look at is the dscp-node. The first thing to do is update the dscp-node and then follow the previous tests from the other pallets and check runtime-benchmarks builds.
 
 If the tests pass create a PR from the **integration** branch.
 

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -4,7 +4,7 @@ This guide will hopefull help in the future when it comes to upgrading Substrate
 
 # First Thing
 
-Make sure you have pulled the main branch, then checkout a branch.
+Make sure you have pulled the main branch. Tthen checkout a integration branch, this branch is where all other project branches will be merged, **NOT INTO MAIN**. As Matt said "that will break up the reviews and make the changes more understandable...and it provides a point of integration so we’re not doing weird `git reset` commands or the like".
 
 # Rustup
 

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -1,18 +1,18 @@
 # Description
 
-This guide will hopefully provide the help and tools to upgrade Substrate in the future.
+This guide will hopefully provide help to upgrade Substrate in the future.
 
 This is a guide based on updating from `0.9.25` to `0.9.30` and the issues it caused can be seen [here](https://github.com/digicatapult/dscp-node/pull/91/files)
 
 # Prerequisities
 
-Create an **integration** branch which all other branches will be PR'd into. This reduces git issues like having to use `git reset`.
+Make sure **main** is up to date and create an **integration** branch which all other branches will be PR'd into. This reduces git issues like having to use `git reset`.
 
 You will need to run `rustup` which is [documented here](https://github.com/digicatapult/dscp-node/blob/main/README.md).
 
 # Upgrade Substrate
 
-This [diener tool](https://crates.io/crates/diener) can be used to update the toml versions fairly painlesslly by upgrading each `cargo.toml` given a specific branch/path.
+This [diener tool](https://crates.io/crates/diener) can be used to update the toml versions easily by upgrading each `cargo.toml` given a specific branch/path.
 
 # Build the Node
 
@@ -28,7 +28,7 @@ After the version updates have been made, depending on the length of time betwee
 
 If a file has errors run `cargo check` and it will only check that one file.
 
-If there are errors you will need to investigate, some may be obvious but it will also be useful to look at the latest version of the branch or use any documentation if available. It may also be worth looking at the [substrate-node-template](https://github.com/substrate-developer-hub/substrate-node-template) to see what what changes they have made when updgrading.
+If there are errors you will need to investigate. It would also be worth looking at the [substrate-node-template](https://github.com/substrate-developer-hub/substrate-node-template) to see what what changes they have made when updgrading and potentially compare code changes between different tagged releases of substrate.
 
 For example, during the `0.9.30` upgrade `Event` and `Origin` became `RuntimeEvent` and
 `RuntimeOrigin`. This information was
@@ -38,7 +38,11 @@ obtained from checking the [Polkadot `0.9.30` branch](https://github.com/parityt
 
 After the change each pallet needs to be inspected, fixed if needed, along with fixes to tests, ensuring the runtime-benchmarks feature build.
 
-Once a pallet has been bought up to date it needs to be tested, something like `cargo test -p pallet-transaction-payment-free`, of course change the pallet name to the pallet you are on. If it passes, push it and potentially into it's own PR into the **integration**. If there are errors Rust is very good at highlighting issues and suggesting looking error codes `rustc --explain E0152 `.
+```bash
+cargo build --release --features runtime-benchmarks
+```
+
+Once a pallet has been brought up to date it needs to be tested, something like `cargo test -p pallet-transaction-payment-free`, of course change the pallet name to the pallet you are on. If it passes, push it into it's own PR, then into the **integration**. If there are errors Rust is very good at highlighting issues and suggesting looking error codes `rustc --explain E0152 `.
 
 ## Runtime
 
@@ -50,6 +54,10 @@ If the tests pass create a PR from the **integration** branch.
 
 The last stop in the node section is to update the dscp-node.
 
-There are several steps to do now, the dscp-node version must be changed and then and then complete the tests and check runtime-benchmarks builds.
+There are two steps to undertake, the dscp-node version must be changed and then and then completion of the tests. If this passes then check runtime-benchmarks builds.
+
+```bash
+cargo build --release --features runtime-benchmarks
+```
 
 Once all of the nodes/pallets have been checked, `cargo fmt` passes and their tests pass a PR can be raised against the **integration** branch into main.

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -30,7 +30,7 @@ If there are errors you will need to investigate, some may be obvious but it wil
 
 For example, during the `0.9.30` upgrade `Event` and `Origin` became `RuntimeEvent` and
 `RuntimeOrigin`. This information was
-obtained from checking the [Polkadot `0.9.30` branch](https://github.com/paritytech/substrate/tree/polkadot-v0.9.30). Checking the branch will help with renaming and syntax changes.
+obtained from checking the [Polkadot `0.9.31` branch](https://github.com/paritytech/substrate/tree/polkadot-v0.9.31). Checking the branch will help with renaming and syntax changes.
 
 # Code Change Example
 

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -55,4 +55,4 @@ let doas_root_unchecked_weight_call = DoasCall::doas_root_unchecked_weight {
         };
 ```
 
-Perhaps the most [difficult part is the changes to the code](https://github.com/digicatapult/dscp-node/pull/91/files#diff-6d40c1b90e071cdb5271cce23374b2ecae20ab264980fda18a4d4d4c290efca1L66), if you look at the original to the new version there are substancial changes (depending on the update).
+Perhaps the most [difficult parts are the changes to the code](https://github.com/digicatapult/dscp-node/pull/91/files#diff-6d40c1b90e071cdb5271cce23374b2ecae20ab264980fda18a4d4d4c290efca1L66), if you look at the original to the new version there are substancial changes (depending on the update).

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -12,7 +12,7 @@ You will need to run `rustup` which is [documented here](https://github.com/digi
 
 ## Upgrade Substrate
 
-This [diener tool](https://crates.io/crates/diener) can be used to update the toml versions easily by upgrading each `cargo.toml` given a specific branch/path.
+This [diener tool](https://crates.io/crates/diener) (which needs to be in the dependencies) can be used to update the toml versions easily by upgrading each `cargo.toml` given a specific branch/path.
 
 ## Build the Node
 

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -41,4 +41,4 @@ let doas_root_unchecked_weight_call = DoasCall::doas_root_unchecked_weight {
         };
 ```
 
-Perhaps the most [difficult parts are the changes to the code](https://github.com/digicatapult/dscp-node/pull/91/files#diff-6d40c1b90e071cdb5271cce23374b2ecae20ab264980fda18a4d4d4c290efca1L66), if you look at the original compared to the new version there could substancial changes (depending on the update).
+Perhaps the most [difficult parts are the changes to the code](https://github.com/digicatapult/dscp-node/pull/91/files#diff-6d40c1b90e071cdb5271cce23374b2ecae20ab264980fda18a4d4d4c290efca1L66), if you look at the original compared against the new version there could substancial changes (depending on the update).

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -26,8 +26,6 @@ This [tool](https://crates.io/crates/diener) can be used to update the version f
 
 After the version updates have been made, depending on the length of time between version releases, there may be a **lot** of changes.
 
-Here is a brief example:
-
 If there are errors you will need to investigate, some may be obvious but it will also be useful to look at the latest version of the branch or use any documentation if available.
 
 For example, during the `0.9.30` upgrade `Event` and `Origin` became `RuntimeEvent` and

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -42,7 +42,7 @@ Once a pallet has been brought up to date it needs to be tested, something like 
 
 ## DSCP-Node
 
-The final node to look at is the dscp-node. The first thing to do is update the dscp-node and then and then complete the tests and check runtime-benchmarks builds.
+The final node to look at is the dscp-node. There are several steps to do now, the dscp-node version must be changed and then and then complete the tests and check runtime-benchmarks builds. And in the Runtime file, roughly line 100, the version must be changed there as a set of numbers, so instead of `5.6.8` it would be `568`
 
 If the tests pass create a PR from the **integration** branch.
 

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -22,7 +22,7 @@ If there are errors you will need to investigate, some may be obvious but it wil
 
 For example, during the `0.9.30` upgrade `Event` and `Origin` became `RuntimeEvent` and
 `RuntimeOrigin`. This information was
-obtained from checking the [Polkadot `0.9.31` branch](https://github.com/paritytech/substrate/tree/polkadot-v0.9.31). Checking the branch will help with renaming and syntax changes.
+obtained from checking the [Polkadot `0.9.30` branch](https://github.com/paritytech/substrate/tree/polkadot-v0.9.30). Checking the branch will help with renaming and syntax changes.
 
 # Build the Node
 

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -52,4 +52,4 @@ The last stop in the node section is to update the dscp-node.
 
 There are several steps to do now, the dscp-node version must be changed and then and then complete the tests and check runtime-benchmarks builds.
 
-Once all of the nodes/pallets have been checked and pass their tests a PR can be raised against the **integration** branch into main.
+Once all of the nodes/pallets have been checked, `cargo fmt` passes and their tests pass a PR can be raised against the **integration** branch into main.

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -16,7 +16,7 @@ Then build the Node:
 cargo build --release
 ```
 
-Depending on the lenght of time between version leases there may be a **lot** of changes.
+After this has built, depending on the length of time between version releases there may be a **lot** of changes.
 
 If there are errors you will need to investigate, some may be obvious but it will also be useful to look at the latest version of the branch or use any documentation if available.
 
@@ -41,4 +41,4 @@ let doas_root_unchecked_weight_call = DoasCall::doas_root_unchecked_weight {
         };
 ```
 
-Perhaps the most [difficult parts are the changes to the code](https://github.com/digicatapult/dscp-node/pull/91/files#diff-6d40c1b90e071cdb5271cce23374b2ecae20ab264980fda18a4d4d4c290efca1L66), if you look at the original to the new version there are substancial changes (depending on the update).
+Perhaps the most [difficult parts are the changes to the code](https://github.com/digicatapult/dscp-node/pull/91/files#diff-6d40c1b90e071cdb5271cce23374b2ecae20ab264980fda18a4d4d4c290efca1L66), if you look at the original compared to the new version there could substancial changes (depending on the update).

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -1,10 +1,12 @@
 # Upgrading Substrate Dependencies
 
-This guide will hopefull help in the future when it comes to upgrading Substrate. It was updated from `0.9.25` to `0.9.30` and the issues it caused can be seen [here](https://github.com/digicatapult/dscp-node/pull/91/files)
+This guide will hopefull help in the future when it comes to upgrading Substrate.
+
+This is a case study of updating from `0.9.25` to `0.9.30` and the issues it caused can be seen [here](https://github.com/digicatapult/dscp-node/pull/91/files)
 
 # First Thing
 
-Make sure you have pulled the main branch. Tthen checkout a integration branch, this branch is where all other project branches will be merged, **NOT INTO MAIN**. As Matt said "that will break up the reviews and make the changes more understandable...and it provides a point of integration so we’re not doing weird `git reset` commands or the like".
+Make sure you have pulled the main branch. Then, as Dave advised, checkout a integration branch, this branch is where all other project branches will be merged, **NOT INTO MAIN**. Matt said "that will break up the reviews and make the changes more understandable...and it provides a point of integration so we’re not doing weird `git reset` commands or the like".
 
 # Rustup
 

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -42,7 +42,7 @@ Once a pallet has been bought up to date it needs to be tested, something like `
 
 ## Runtime
 
-In the Runtime file, lib.rs, roughly line 100, the version must be changed there as a set of numbers, so instead of `5.6.8` it would be `568`, for example `spec_version: 444`
+In the Runtime file, lib.rs the version must be changed there as a set of numbers, so instead of `5.6.8` it would be `568`, for example `spec_version: 444`
 
 If the tests pass create a PR from the **integration** branch.
 

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -42,7 +42,7 @@ Once a pallet has been bought up to date it needs to be tested, something like `
 
 ## Runtime
 
-Inn the Runtime file, lib.rs, roughly line 100, the version must be changed there as a set of numbers, so instead of `5.6.8` it would be `568`, for example `spec_version: 444`
+In the Runtime file, lib.rs, roughly line 100, the version must be changed there as a set of numbers, so instead of `5.6.8` it would be `568`, for example `spec_version: 444`
 
 If the tests pass create a PR from the **integration** branch.
 

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -12,7 +12,7 @@ You will need to run `rustup` which is [documented here](https://github.com/digi
 
 # Upgrade Substrate
 
-This [diener tool](https://crates.io/crates/diener) can be used to update the `toml` versions fairly painlesslly by upgrading each `cargo.toml` given a specific branch/path.
+This [diener tool](https://crates.io/crates/diener) can be used to update the `cargo.toml` versions fairly painlesslly by upgrading each `cargo.toml` given a specific branch/path.
 
 # Build the Node
 

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -1,16 +1,3 @@
-##Code Changes
-...
-
-### Pallets
-
-...
-
-### Runtime
-
-...
-
-### Node
-
 # Description
 
 This guide will hopefully help upgrade Substrate in the future.

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -1,4 +1,4 @@
-# Description
+# Upgrading Substrate dependencies
 
 This guide will hopefully provide help to upgrade Substrate in the future.
 
@@ -16,7 +16,7 @@ This [diener tool](https://crates.io/crates/diener) can be used to update the to
 
 `cargo install diener`
 and in the root of the `dscp-node` directory run `diener update --substrate --branch polkadot-v0.9.30`
-## Build the Node
+### Test Building the Node
 
 To build the Node:
 
@@ -24,7 +24,7 @@ To build the Node:
 cargo build --release --features runtime-benchmarks
 ```
 
-## Pallets
+### Pallets
 
 Once the version updates have been made we should try to build a pallet, in this example we shall try to build the `pallet-doas` in isolation.
 
@@ -49,7 +49,7 @@ Once a pallet has been brought up to date it needs to be tested, something like
 
 If it passes, bump its version in the pallets `pallets/doas/Cargo.toml` push it into it's own PR, then into the **integration** branch
 
-## Runtime
+### Runtime
 
 We now need to test that the upgraded dependencies work for the runtime including our newly upgraded pallets.  So firstly replace all the pallet versions in the runtime's `runtime/Cargo.toml` and then we need to test a runtime build, we do this by
 `cargo build --release -p dscp-node-runtime`
@@ -63,7 +63,7 @@ We should now run the tests for the runtime, which we can do using:
 
 If the tests pass create a PR from the **integration** branch.
 
-## Node
+### Node
 
 The last item to upgrade is the `dscp-node` itself.
 

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -15,7 +15,7 @@ You will need to run `rustup` which is [documented here](https://github.com/digi
 This [diener tool](https://crates.io/crates/diener) can be used to update the toml versions easily by upgrading each `cargo.toml` given a specific branch/path
 
 `cargo install diener`
-and in the root of the `dscp-node` directory run `diener update --substrate --branch polkadot-v0.9.{version}`
+and in the root of the `dscp-node` directory run `diener update --substrate --branch polkadot-v0.9.<var>`
 
 ### Test Building the Node
 

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -22,6 +22,8 @@ To build the Node:
 cargo build --release
 ```
 
+# Pallets
+
 After the version updates have been made, depending on the length of time between version releases, there may be a **lot** of changes.
 
 If there are errors you will need to investigate, some may be obvious but it will also be useful to look at the latest version of the branch or use any documentation if available. It may also be worth looking at the [substrate-node-template](https://github.com/substrate-developer-hub/substrate-node-template) to see what what changes they have made when updgrading.
@@ -29,8 +31,6 @@ If there are errors you will need to investigate, some may be obvious but it wil
 For example, during the `0.9.30` upgrade `Event` and `Origin` became `RuntimeEvent` and
 `RuntimeOrigin`. This information was
 obtained from checking the [Polkadot `0.9.30` branch](https://github.com/paritytech/substrate/tree/polkadot-v0.9.30). Checking the branch will help with renaming and syntax changes.
-
-# Pallets
 
 [Version changes can be the most difficult parts of the code](https://github.com/digicatapult/dscp-node/pull/91/files#diff-6d40c1b90e071cdb5271cce23374b2ecae20ab264980fda18a4d4d4c290efca1), if you look at the original compared against the new version there could substancial, or minor, changes (depending on the update).
 

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -1,6 +1,6 @@
 # Description
 
-This guide will hopefully help upgrade Substrate in the future.
+This guide will hopefully provide the help and tools to upgrade Substrate in the future.
 
 This is a guide based on updating from `0.9.25` to `0.9.30` and the issues it caused can be seen [here](https://github.com/digicatapult/dscp-node/pull/91/files)
 
@@ -12,7 +12,7 @@ You will need to run `rustup` which is [documented here](https://github.com/digi
 
 # Upgrade Substrate
 
-This [diener tool](https://crates.io/crates/diener) can be used to update the file versions fairly painlesslly.
+This [diener tool](https://crates.io/crates/diener) can be used to update the file versions fairly painlesslly by upgrading each `cargo.toml` given a specific branch/path.
 
 After the version updates have been made, depending on the length of time between version releases, there may be a **lot** of changes.
 
@@ -32,22 +32,22 @@ cargo build --release
 
 # Pallets
 
-[Version changes can be the most difficult parts of the code](https://github.com/digicatapult/dscp-node/pull/91/files#diff-6d40c1b90e071cdb5271cce23374b2ecae20ab264980fda18a4d4d4c290efca1), if you look at the original compared against the new version there could substancial changes (depending on the update).
+[Version changes can be the most difficult parts of the code](https://github.com/digicatapult/dscp-node/pull/91/files#diff-6d40c1b90e071cdb5271cce23374b2ecae20ab264980fda18a4d4d4c290efca1), if you look at the original compared against the new version there could substancial, or minor, changes (depending on the update).
 
-After the change each pallet needs to be inspected, fixed if needed, along with fixes to tests and ensuring the runtime-benchmarks feature build.
+After the change each pallet needs to be inspected, fixed if needed, along with fixes to tests, ensuring the runtime-benchmarks feature build.
 
-Once a pallet has been brought up to date it needs to be tested, something like `cargo test -p pallet-transaction-payment-free`, of course change the pallet name to what is necessary. If it passes push it and potentially into it's own PR into the **integration**. If there are errors Rust is very good at highlighting issues and suggesting looking error codes `rustc --explain E0152 `.
-
-## Node
-
-The last stop in the node section is to update the dscp-node.
-
-There are several steps to do now, the dscp-node version must be changed and then and then complete the tests and check runtime-benchmarks builds.
+Once a pallet has been bought up to date it needs to be tested, something like `cargo test -p pallet-transaction-payment-free`, of course change the pallet name to the pallet you are on. If it passes, push it and potentially into it's own PR into the **integration**. If there are errors Rust is very good at highlighting issues and suggesting looking error codes `rustc --explain E0152 `.
 
 ## Runtime
 
 Inn the Runtime file, lib.rs, roughly line 100, the version must be changed there as a set of numbers, so instead of `5.6.8` it would be `568`, for example `spec_version: 444`
 
 If the tests pass create a PR from the **integration** branch.
+
+## Node
+
+The last stop in the node section is to update the dscp-node.
+
+There are several steps to do now, the dscp-node version must be changed and then and then complete the tests and check runtime-benchmarks builds.
 
 Once all of the nodes/pallets have been checked and pass their tests a PR can be raised against the **integration** branch into main.

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -28,7 +28,7 @@ After the version updates have been made, depending on the length of time betwee
 
 If there are errors you will need to investigate, some may be obvious but it will also be useful to look at the latest version of the branch or use any documentation if available.
 
-For example, during the `0.9.30` upgrade `Event` and `Origin` became `RuntimeEvent` and
+For example, during the `0.9.31` upgrade `Event` and `Origin` became `RuntimeEvent` and
 `RuntimeOrigin`. This information was
 obtained from checking the [Polkadot `0.9.31` branch](https://github.com/paritytech/substrate/tree/polkadot-v0.9.31). Checking the branch will help with renaming and syntax changes.
 

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -53,7 +53,7 @@ let doas_root_unchecked_weight_call = DoasCall::doas_root_unchecked_weight {
 
 After the change each pallet needs to be inspected, fixed if needed, along with fixes to tests and ensuring the runtime-benchmarks feature build.
 
-Once a pallet is working it should be put into it's own PR into the **integration**.
+Once a pallet has been brought up to date it needs to be tested, something like `cargo test -p pallet-transaction-payment-free`, of course change the pallet name to what is necessary. If it passes push it and potentially into it's own PR into the **integration**.
 
 ## DSCP-Node
 

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -42,7 +42,7 @@ Once a pallet has been brought up to date it needs to be tested, something like 
 
 ## DSCP-Node
 
-The final node to look at is the dscp-node. There are several steps to do now, the dscp-node version must be changed and then and then complete the tests and check runtime-benchmarks builds. And in the Runtime file, roughly line 100, the version must be changed there as a set of numbers, so instead of `5.6.8` it would be `568`, for example `spec_version: 444`
+The final node to look at is the dscp-node. There are several steps to do now, the dscp-node version must be changed and then and then complete the tests and check runtime-benchmarks builds. And in the Runtime file lib.rs file, roughly line 100, the version must be changed there as a set of numbers, so instead of `5.6.8` it would be `568`, for example `spec_version: 444`
 
 If the tests pass create a PR from the **integration** branch.
 

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -8,8 +8,6 @@ This is a guide based on updating from `0.9.25` to `0.9.30` and the issues it ca
 
 Create an **integration** branch which all other branches will be PR'd into. This reduces git issues like having to use `git reset`.
 
-Upgrade the references to the [paritytech/substrate](https://github.com/paritytech/substrate) repo in each of the workspace cargo.toml files. Doing this it will help ensure that the `cargo build` (as seen below) works and the rest of the process can take place.
-
 You will need to run `rustup` which is [documented here](https://github.com/digicatapult/dscp-node/blob/main/README.md).
 
 # Upgrade Substrate


### PR DESCRIPTION
This follow the process that was used upgrading Polkadot 0.9.25 to 0.9.30. It also links to other repos which contain other useful information. 

It also references [diener](https://crates.io/crates/diener), a crate which makes changing Substrate and Polkadot version easier.
