### PR TITLE
Improve schedule tests on symmetric key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1347,7 +1347,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "dscp-node"
-version = "4.4.7"
+version = "4.4.8"
 dependencies = [
  "bs58",
  "clap",
@@ -1390,7 +1390,7 @@ dependencies = [
 
 [[package]]
 name = "dscp-node-runtime"
-version = "4.4.7"
+version = "4.4.8"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",
@@ -4216,7 +4216,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-symmetric-key"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-node",
-  "version": "4.4.7",
+  "version": "4.4.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-node",
-      "version": "4.4.7",
+      "version": "4.4.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^8.11.3"

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-node",
-  "version": "4.4.7",
+  "version": "4.4.8",
   "description": "DSCP node types",
   "repository": {
     "type": "git",

--- a/helm/dscp-node/Chart.yaml
+++ b/helm/dscp-node/Chart.yaml
@@ -6,5 +6,5 @@ maintainers:
     url: www.digicatapult.org.uk
 description: A Helm chart to deploy DSCP nodes
 type: application
-version: 4.4.7
-appVersion: '4.4.7'
+version: 4.4.8
+appVersion: '4.4.8'

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -6,7 +6,7 @@ edition = '2021'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/dscp-node/'
 name = 'dscp-node'
-version = '4.4.7'
+version = '4.4.8'
 
 [[bin]]
 name = 'dscp-node'
@@ -61,7 +61,7 @@ frame-benchmarking = { version = "4.0.0-dev", git = "https://github.com/parityte
 frame-benchmarking-cli = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.32" }
 
 # Local Dependencies
-dscp-node-runtime = { path = '../runtime', version = '4.4.7' }
+dscp-node-runtime = { path = '../runtime', version = '4.4.8' }
 
 # CLI-specific dependencies
 try-runtime-cli = { version = "0.10.0-dev", optional = true, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.32" }

--- a/pallets/symmetric-key/Cargo.toml
+++ b/pallets/symmetric-key/Cargo.toml
@@ -5,7 +5,7 @@ edition = '2021'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/dscp-node/'
 name = 'pallet-symmetric-key'
-version = "2.0.0"
+version = "2.0.1"
 
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']

--- a/pallets/symmetric-key/src/lib.rs
+++ b/pallets/symmetric-key/src/lib.rs
@@ -70,6 +70,8 @@ pub mod pallet {
     #[pallet::hooks]
     impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
         fn on_initialize(_block_number: T::BlockNumber) -> frame_support::weights::Weight {
+            use sp_runtime::traits::Zero;
+
             let existing_schedule = <KeyScheduleId<T>>::get();
 
             match existing_schedule {
@@ -77,7 +79,7 @@ pub mod pallet {
                     let id: Vec<u8> = KEY_ROTATE_ID.encode();
                     if T::Scheduler::schedule_named(
                         id.clone(),
-                        DispatchTime::After(T::BlockNumber::from(1u32)),
+                        DispatchTime::After(T::BlockNumber::zero()),
                         Some((T::RefreshPeriod::get(), u32::max_value())),
                         LOWEST_PRIORITY,
                         frame_system::RawOrigin::Root.into(),

--- a/pallets/symmetric-key/src/tests/rotate_key.rs
+++ b/pallets/symmetric-key/src/tests/rotate_key.rs
@@ -7,18 +7,19 @@ use frame_support::{assert_err, assert_ok, bounded_vec, dispatch::DispatchError}
 #[test]
 fn rotate_key_as_root() {
     new_test_ext().execute_with(|| {
+        run_to_block(1);
+
         let init_key = bounded_vec![
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28,
             29, 30, 31
         ];
-        let new_key = bounded_vec![
-            83, 89, 77, 77, 69, 84, 82, 73, 67, 95, 75, 69, 89, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0,
-        ];
         SymmetricKey::update_key(RuntimeOrigin::root(), init_key).unwrap();
-        System::set_block_number(1);
 
         assert_ok!(SymmetricKey::rotate_key(RuntimeOrigin::root()));
+
+        let new_key = bounded_vec![
+            8, 9, 10, 11, 12, 13, 14, 15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+        ];
         assert_eq!(SymmetricKey::key(), new_key);
         assert_eq!(
             System::events().iter().last().unwrap().event,
@@ -30,6 +31,8 @@ fn rotate_key_as_root() {
 #[test]
 fn rotate_key_not_as_root() {
     new_test_ext().execute_with(|| {
+        run_to_block(1);
+
         let init_key: BoundedVec<u8, ConstU32<32>> = bounded_vec![
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28,
             29, 30, 31

--- a/pallets/symmetric-key/src/tests/schedule.rs
+++ b/pallets/symmetric-key/src/tests/schedule.rs
@@ -8,6 +8,7 @@ use crate::Event;
 fn schedule_before_first_call() {
     new_test_ext().execute_with(|| {
         SymmetricKey::on_initialize(System::block_number());
+        run_to_block(1);
 
         let init_key: BoundedVec<u8, ConstU32<32>> = bounded_vec![
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28,
@@ -15,13 +16,35 @@ fn schedule_before_first_call() {
         ];
         SymmetricKey::update_key(RuntimeOrigin::root(), init_key.clone()).unwrap();
 
-        for _bn in 1..2 {
-            Scheduler::on_finalize(System::block_number());
-            System::set_block_number(System::block_number() + 1);
-            Scheduler::on_initialize(System::block_number());
-        }
+        run_to_block(3);
 
         assert_eq!(SymmetricKey::key(), init_key);
+    });
+}
+
+#[test]
+fn schedule_after_first_schedule() {
+    new_test_ext().execute_with(|| {
+        SymmetricKey::on_initialize(System::block_number());
+        run_to_block(1);
+
+        let init_key = bounded_vec![
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28,
+            29, 30, 31
+        ];
+        SymmetricKey::update_key(RuntimeOrigin::root(), init_key).unwrap();
+
+        let new_key = bounded_vec![
+            48, 49, 50, 51, 52, 53, 54, 55, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+        ];
+
+        run_to_block(6);
+
+        assert_eq!(SymmetricKey::key(), new_key);
+        assert_eq!(
+            System::events().iter().rev().nth(2).unwrap().event,
+            TestEvent::SymmetricKey(Event::UpdateKey(new_key)),
+        )
     });
 }
 
@@ -29,27 +52,32 @@ fn schedule_before_first_call() {
 fn schedule_after_schedule_period() {
     new_test_ext().execute_with(|| {
         SymmetricKey::on_initialize(System::block_number());
+        run_to_block(1);
 
         let init_key = bounded_vec![
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28,
             29, 30, 31
         ];
-        let new_key = bounded_vec![
-            83, 89, 77, 77, 69, 84, 82, 73, 67, 95, 75, 69, 89, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0,
-        ];
         SymmetricKey::update_key(RuntimeOrigin::root(), init_key).unwrap();
 
-        for _bn in 1..5 {
-            Scheduler::on_finalize(System::block_number());
-            System::set_block_number(System::block_number() + 1);
-            Scheduler::on_initialize(System::block_number());
-        }
+        let new_key = bounded_vec![
+            88, 89, 90, 91, 92, 93, 94, 95, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ];
+
+        run_to_block(11);
 
         assert_eq!(SymmetricKey::key(), new_key);
-        assert_eq!(
-            System::events().iter().rev().nth(2).unwrap().event,
-            TestEvent::SymmetricKey(Event::UpdateKey(new_key)),
-        )
+
+        let events = System::events();
+        let last_key_update = &events
+            .iter()
+            .rev()
+            .find(|&x| match x.event {
+                TestEvent::SymmetricKey(Event::UpdateKey(_)) => true,
+                _ => false
+            })
+            .unwrap()
+            .event;
+        assert_eq!(last_key_update, &TestEvent::SymmetricKey(Event::UpdateKey(new_key)),)
     });
 }

--- a/pallets/symmetric-key/src/tests/update_key.rs
+++ b/pallets/symmetric-key/src/tests/update_key.rs
@@ -9,10 +9,10 @@ use frame_support::{assert_noop, assert_ok, dispatch::DispatchError};
 #[test]
 fn update_key_as_root() {
     new_test_ext().execute_with(|| {
+        run_to_block(1);
         let new_key: BoundedVec<u8, _> = bounded_vec![
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
         ];
-        System::set_block_number(1);
 
         assert_ok!(SymmetricKey::update_key(RuntimeOrigin::root(), new_key.clone()));
         assert_eq!(SymmetricKey::key(), new_key);
@@ -26,6 +26,8 @@ fn update_key_as_root() {
 #[test]
 fn update_key_not_as_root() {
     new_test_ext().execute_with(|| {
+        run_to_block(1);
+
         let init_key: BoundedVec<u8, _> = bounded_vec![
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
         ];
@@ -45,6 +47,8 @@ fn update_key_not_as_root() {
 #[test]
 fn update_key_incorrect_key_length() {
     new_test_ext().execute_with(|| {
+        run_to_block(1);
+
         let init_key: BoundedVec<u8, _> = bounded_vec![
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
         ];

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dscp-node-runtime"
-version = "4.4.7"
+version = "4.4.8"
 authors = ["Digital Catapult <https://www.digicatapult.org.uk>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -62,7 +62,7 @@ hex-literal = { version = "0.3.4", optional = true }
 pallet-doas = { version = '2.0.0', default-features = false, package = 'pallet-doas', path = '../pallets/doas' }
 pallet-simple-nft = { version = '4.0.0', default-features = false, package = 'pallet-simple-nft', path = '../pallets/simple-nft' }
 pallet-process-validation = { version = '3.1.1', default-features = false, package = 'pallet-process-validation', path = '../pallets/process-validation' }
-pallet-symmetric-key = { version = '2.0.0', default-features = false, package = 'pallet-symmetric-key', path = '../pallets/symmetric-key' }
+pallet-symmetric-key = { version = '2.0.1', default-features = false, package = 'pallet-symmetric-key', path = '../pallets/symmetric-key' }
 pallet-transaction-payment-free = { default-features = false, version = '2.0.0', package = 'pallet-transaction-payment-free', path = '../pallets/transaction-payment-free' }
 
 [build-dependencies]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -97,7 +97,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("dscp"),
     impl_name: create_runtime_str!("dscp"),
     authoring_version: 1,
-    spec_version: 447,
+    spec_version: 448,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
The current test logic on `pallet-symmetric-key`'s `schedule` tests is a bit flawed. The intension is to assert that the schedule indeed runs automatically on an interval but the tests don’t actually do this. Instead what’s happening is the schedule is initialised once (and this is tested), but the following interval is not. This ticket will look to improve the tests by

- making explicit that the existing test is only testing the schedule initialisation
- adding another test to assert that the schedule indeed fires on an interval

To achieve the latter case I had to implement our own `TestRandomness` as the one in substrate doesn’t actually change.
