### PR TITLE
Feature/process validation genesis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1347,7 +1347,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "dscp-node"
-version = "4.4.8"
+version = "4.5.0"
 dependencies = [
  "bs58",
  "clap",
@@ -1390,7 +1390,7 @@ dependencies = [
 
 [[package]]
 name = "dscp-node-runtime"
-version = "4.4.8"
+version = "4.5.0"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",
@@ -1419,6 +1419,7 @@ dependencies = [
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
  "scale-info",
+ "serde",
  "sp-api",
  "sp-block-builder",
  "sp-consensus-aura",
@@ -4117,7 +4118,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-process-validation"
-version = "3.1.1"
+version = "3.2.0"
 dependencies = [
  "dscp-pallet-traits",
  "frame-benchmarking",

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-node",
-  "version": "4.4.8",
+  "version": "4.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-node",
-      "version": "4.4.8",
+      "version": "4.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^8.11.3"

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-node",
-  "version": "4.4.8",
+  "version": "4.5.0",
   "description": "DSCP node types",
   "repository": {
     "type": "git",

--- a/helm/dscp-node/Chart.yaml
+++ b/helm/dscp-node/Chart.yaml
@@ -6,5 +6,5 @@ maintainers:
     url: www.digicatapult.org.uk
 description: A Helm chart to deploy DSCP nodes
 type: application
-version: 4.4.8
-appVersion: '4.4.8'
+version: 4.5.0
+appVersion: '4.5.0'

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -6,7 +6,7 @@ edition = '2021'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/dscp-node/'
 name = 'dscp-node'
-version = '4.4.8'
+version = '4.5.0'
 
 [[bin]]
 name = 'dscp-node'
@@ -61,7 +61,7 @@ frame-benchmarking = { version = "4.0.0-dev", git = "https://github.com/parityte
 frame-benchmarking-cli = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.32" }
 
 # Local Dependencies
-dscp-node-runtime = { path = '../runtime', version = '4.4.8' }
+dscp-node-runtime = { path = '../runtime' }
 
 # CLI-specific dependencies
 try-runtime-cli = { version = "0.10.0-dev", optional = true, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.32" }

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -1,6 +1,7 @@
 use dscp_node_runtime::{
+    types::{BooleanExpressionSymbol, Restriction},
     AccountId, AuraConfig, BalancesConfig, GenesisConfig, GrandpaConfig, MembershipConfig, NodeAuthorizationConfig,
-    ProcessValidationConfig, Signature, SudoConfig, SystemConfig, WASM_BINARY, types::{BooleanExpressionSymbol, Restriction}
+    ProcessValidationConfig, Signature, SudoConfig, SystemConfig, WASM_BINARY
 };
 use sc_service::ChainType;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -1,13 +1,16 @@
 use dscp_node_runtime::{
     AccountId, AuraConfig, BalancesConfig, GenesisConfig, GrandpaConfig, MembershipConfig, NodeAuthorizationConfig,
-    Signature, SudoConfig, SystemConfig, WASM_BINARY
+    ProcessValidationConfig, Signature, SudoConfig, SystemConfig, WASM_BINARY, types::{BooleanExpressionSymbol, Restriction}
 };
 use sc_service::ChainType;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_core::OpaquePeerId; // A struct wraps Vec<u8>, represents as our `PeerId`.
 use sp_core::{sr25519, Pair, Public};
 use sp_finality_grandpa::AuthorityId as GrandpaId;
-use sp_runtime::traits::{IdentifyAccount, Verify};
+use sp_runtime::{
+    bounded_vec,
+    traits::{IdentifyAccount, Verify}
+};
 const DEFAULT_PROTOCOL_ID: &str = "dscp";
 
 // The URL for the telemetry server.
@@ -220,6 +223,12 @@ fn testnet_genesis(
             members: technical_committee_accounts.try_into().unwrap(),
             ..Default::default()
         },
-        technical_committee: Default::default()
+        technical_committee: Default::default(),
+        process_validation: ProcessValidationConfig {
+            processes: vec![(
+                "default".as_bytes().to_vec().try_into().unwrap(),
+                bounded_vec![BooleanExpressionSymbol::Restriction(Restriction::None)]
+            )]
+        }
     }
 }

--- a/pallets/process-validation/Cargo.toml
+++ b/pallets/process-validation/Cargo.toml
@@ -5,13 +5,14 @@ edition = '2021'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/dscp-node/'
 name = 'pallet-process-validation'
-version = "3.1.1"
+version = "3.2.0"
 
 
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
+serde = { version = "1.0.137", optional = true }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 dscp-pallet-traits = { version = '3.0.0', default-features = false, path = '../traits' }
@@ -22,11 +23,8 @@ sp-runtime = { default-features = false, version = "6.0.0", git = "https://githu
 sp-io = { default-features = false, version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.32" }
 sp-std = { default-features = false, version = "4.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.32" }
 
-
 [dev-dependencies]
-serde = { version = "1.0.137" }
 sp-core = { default-features = false, version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.32" }
-
 
 [features]
 default = ['std']
@@ -35,6 +33,7 @@ std = [
     'frame-support/std',
     'frame-system/std',
     'frame-benchmarking/std',
+    'serde',
     'sp-std/std',
     'dscp-pallet-traits/std',
 ]

--- a/pallets/process-validation/src/binary_expression_tree.rs
+++ b/pallets/process-validation/src/binary_expression_tree.rs
@@ -1,9 +1,12 @@
 use codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
+#[cfg(feature = "std")]
+use serde::{Deserialize, Serialize};
 
 use crate::Restriction;
 
 #[derive(Encode, Decode, Debug, Clone, MaxEncodedLen, TypeInfo, PartialEq)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub enum BooleanOperator {
     Null,         // false
     Identity,     // true
@@ -24,6 +27,7 @@ pub enum BooleanOperator {
 }
 
 #[derive(Encode, Decode, Debug, Clone, MaxEncodedLen, TypeInfo, PartialEq)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub enum BooleanExpressionSymbol<RoleKey, TokenMetadataKey, TokenMetadataValue, TokenMetadataValueDiscriminator> {
     Op(BooleanOperator),
     Restriction(Restriction<RoleKey, TokenMetadataKey, TokenMetadataValue, TokenMetadataValueDiscriminator>)

--- a/pallets/process-validation/src/lib.rs
+++ b/pallets/process-validation/src/lib.rs
@@ -183,6 +183,9 @@ pub mod pallet {
     impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
         fn build(&self) {
             for (process_id, program) in self.processes.iter() {
+                if !Pallet::<T>::validate_program(&program) {
+                    panic!("Invalid program detected in genesis!")
+                }
                 let version = Pallet::<T>::update_version(process_id).unwrap();
                 Pallet::<T>::persist_process(process_id, &version, program).unwrap();
             }
@@ -245,7 +248,7 @@ pub mod pallet {
             T::CreateProcessOrigin::ensure_origin(origin)?;
 
             ensure!(
-                Pallet::<T>::validate_program(program.clone()),
+                Pallet::<T>::validate_program(&program),
                 Error::<T>::InvalidProgram
             );
 
@@ -280,7 +283,7 @@ pub mod pallet {
     // helper methods
     impl<T: Config> Pallet<T> {
         pub fn validate_program(
-            program: BoundedVec<
+            program: &BoundedVec<
                 BooleanExpressionSymbol<
                     T::RoleKey,
                     T::TokenMetadataKey,

--- a/pallets/process-validation/src/lib.rs
+++ b/pallets/process-validation/src/lib.rs
@@ -247,10 +247,7 @@ pub mod pallet {
         ) -> DispatchResultWithPostInfo {
             T::CreateProcessOrigin::ensure_origin(origin)?;
 
-            ensure!(
-                Pallet::<T>::validate_program(&program),
-                Error::<T>::InvalidProgram
-            );
+            ensure!(Pallet::<T>::validate_program(&program), Error::<T>::InvalidProgram);
 
             let version: T::ProcessVersion = Pallet::<T>::update_version(&id).unwrap();
             Pallet::<T>::persist_process(&id, &version, &program)?;

--- a/pallets/process-validation/src/lib.rs
+++ b/pallets/process-validation/src/lib.rs
@@ -17,10 +17,10 @@ mod benchmarking;
 
 // import the restrictions module where all our restriction types are defined
 mod restrictions;
-use restrictions::*;
+pub use restrictions::*;
 
 mod binary_expression_tree;
-use binary_expression_tree::*;
+pub use binary_expression_tree::*;
 
 #[derive(Encode, Debug, Decode, Clone, MaxEncodedLen, TypeInfo, PartialEq)]
 pub enum ProcessStatus {
@@ -105,7 +105,7 @@ pub mod pallet {
         /// The overarching event type.
         type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
         // The primary identifier for a process (i.e. it's name, and version)
-        type ProcessIdentifier: Parameter + Default + MaxEncodedLen;
+        type ProcessIdentifier: Parameter + Default + MaxEncodedLen + MaybeSerializeDeserialize;
         type ProcessVersion: Parameter + AtLeast32Bit + Default + MaxEncodedLen;
 
         #[pallet::constant]
@@ -115,10 +115,14 @@ pub mod pallet {
         type CreateProcessOrigin: EnsureOrigin<Self::RuntimeOrigin>;
         type DisableProcessOrigin: EnsureOrigin<Self::RuntimeOrigin>;
 
-        type RoleKey: Parameter + Default + Ord + MaxEncodedLen;
-        type TokenMetadataKey: Parameter + Default + Ord + MaxEncodedLen;
-        type TokenMetadataValue: Parameter + Default + MaxEncodedLen;
-        type TokenMetadataValueDiscriminator: Parameter + Default + From<Self::TokenMetadataValue> + MaxEncodedLen;
+        type RoleKey: Parameter + Default + Ord + MaxEncodedLen + MaybeSerializeDeserialize;
+        type TokenMetadataKey: Parameter + Default + Ord + MaxEncodedLen + MaybeSerializeDeserialize;
+        type TokenMetadataValue: Parameter + Default + MaxEncodedLen + MaybeSerializeDeserialize;
+        type TokenMetadataValueDiscriminator: Parameter
+            + Default
+            + From<Self::TokenMetadataValue>
+            + MaxEncodedLen
+            + MaybeSerializeDeserialize;
 
         // Origin for overriding weight calculation implementation
         type WeightInfo: WeightInfo;
@@ -151,6 +155,39 @@ pub mod pallet {
     #[pallet::getter(fn version_model)]
     pub(super) type VersionModel<T: Config> =
         StorageMap<_, Blake2_128Concat, T::ProcessIdentifier, T::ProcessVersion, ValueQuery>;
+
+    #[pallet::genesis_config]
+    pub struct GenesisConfig<T: Config> {
+        pub processes: Vec<(
+            T::ProcessIdentifier,
+            BoundedVec<
+                BooleanExpressionSymbol<
+                    T::RoleKey,
+                    T::TokenMetadataKey,
+                    T::TokenMetadataValue,
+                    T::TokenMetadataValueDiscriminator
+                >,
+                T::MaxProcessProgramLength
+            >
+        )>
+    }
+
+    #[cfg(feature = "std")]
+    impl<T: Config> Default for GenesisConfig<T> {
+        fn default() -> Self {
+            Self { processes: Vec::new() }
+        }
+    }
+
+    #[pallet::genesis_build]
+    impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
+        fn build(&self) {
+            for (process_id, program) in self.processes.iter() {
+                let version = Pallet::<T>::update_version(process_id).unwrap();
+                Pallet::<T>::persist_process(process_id, &version, program).unwrap();
+            }
+        }
+    }
 
     #[pallet::event]
     #[pallet::generate_deposit(pub(super) fn deposit_event)]
@@ -212,7 +249,7 @@ pub mod pallet {
                 Error::<T>::InvalidProgram
             );
 
-            let version: T::ProcessVersion = Pallet::<T>::update_version(id.clone()).unwrap();
+            let version: T::ProcessVersion = Pallet::<T>::update_version(&id).unwrap();
             Pallet::<T>::persist_process(&id, &version, &program)?;
 
             Self::deposit_event(Event::ProcessCreated(
@@ -271,11 +308,11 @@ pub mod pallet {
             };
         }
 
-        pub fn update_version(id: T::ProcessIdentifier) -> Result<T::ProcessVersion, Error<T>> {
-            let version: T::ProcessVersion = Pallet::<T>::get_next_version(&id);
+        pub fn update_version(id: &T::ProcessIdentifier) -> Result<T::ProcessVersion, Error<T>> {
+            let version: T::ProcessVersion = Pallet::<T>::get_next_version(id);
             match version == One::one() {
-                true => <VersionModel<T>>::insert(&id, version.clone()),
-                false => <VersionModel<T>>::mutate(&id, |v| *v = version.clone())
+                true => <VersionModel<T>>::insert(id, version.clone()),
+                false => <VersionModel<T>>::mutate(id, |v| *v = version.clone())
             };
 
             return Ok(version);

--- a/pallets/process-validation/src/restrictions.rs
+++ b/pallets/process-validation/src/restrictions.rs
@@ -5,9 +5,12 @@ use codec::{Decode, Encode, MaxEncodedLen};
 use dscp_pallet_traits::ProcessIO;
 use frame_support::Parameter;
 use scale_info::TypeInfo;
+#[cfg(feature = "std")]
+use serde::{Deserialize, Serialize};
 use sp_std::vec::Vec;
 
 #[derive(Encode, Decode, Debug, Clone, MaxEncodedLen, TypeInfo, PartialEq)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub enum Restriction<RoleKey, TokenMetadataKey, TokenMetadataValue, TokenMetadataValueDiscriminator> {
     None,
     Fail,

--- a/pallets/process-validation/src/tests.rs
+++ b/pallets/process-validation/src/tests.rs
@@ -4,7 +4,7 @@ use crate as pallet_process_validation;
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{
     parameter_types,
-    traits::{ConstU32, ConstU64}
+    traits::{ConstU32, ConstU64, GenesisBuild}
 };
 use frame_system as system;
 use scale_info::TypeInfo;
@@ -19,6 +19,7 @@ use sp_runtime::{
 mod create_process;
 mod disable_process;
 mod validate_process;
+mod genesis;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
@@ -114,4 +115,10 @@ impl pallet_process_validation::Config for Test {
 // our desired mockup.
 pub fn new_test_ext() -> sp_io::TestExternalities {
     system::GenesisConfig::default().build_storage::<Test>().unwrap().into()
+}
+
+pub fn new_test_ext_with_genesis(genesis: pallet_process_validation::GenesisConfig::<Test>) -> sp_io::TestExternalities {
+    let mut t = system::GenesisConfig::default().build_storage::<Test>().unwrap().into();
+    genesis.assimilate_storage(&mut t).unwrap();
+    t.into()
 }

--- a/pallets/process-validation/src/tests.rs
+++ b/pallets/process-validation/src/tests.rs
@@ -18,8 +18,8 @@ use sp_runtime::{
 
 mod create_process;
 mod disable_process;
-mod validate_process;
 mod genesis;
+mod validate_process;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
@@ -117,7 +117,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
     system::GenesisConfig::default().build_storage::<Test>().unwrap().into()
 }
 
-pub fn new_test_ext_with_genesis(genesis: pallet_process_validation::GenesisConfig::<Test>) -> sp_io::TestExternalities {
+pub fn new_test_ext_with_genesis(genesis: pallet_process_validation::GenesisConfig<Test>) -> sp_io::TestExternalities {
     let mut t = system::GenesisConfig::default().build_storage::<Test>().unwrap().into();
     genesis.assimilate_storage(&mut t).unwrap();
     t.into()

--- a/pallets/process-validation/src/tests.rs
+++ b/pallets/process-validation/src/tests.rs
@@ -8,6 +8,8 @@ use frame_support::{
 };
 use frame_system as system;
 use scale_info::TypeInfo;
+#[cfg(feature = "std")]
+use serde::{Deserialize, Serialize};
 use sp_core::H256;
 use sp_runtime::{
     testing::Header,
@@ -69,6 +71,7 @@ impl system::Config for Test {
 }
 
 #[derive(Encode, Decode, Clone, MaxEncodedLen, TypeInfo, PartialEq, Debug, Eq)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub enum ProcessIdentifier {
     A,
     B
@@ -81,6 +84,7 @@ impl Default for ProcessIdentifier {
 }
 
 #[derive(Encode, Decode, Clone, MaxEncodedLen, TypeInfo, PartialEq, Debug, Default, Eq)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub struct TokenMetadataValueDiscriminator {
     value: u8
 }

--- a/pallets/process-validation/src/tests/create_process.rs
+++ b/pallets/process-validation/src/tests/create_process.rs
@@ -97,9 +97,9 @@ fn if_no_version_found_it_should_return_default_and_insert_new_one() {
 fn for_existing_process_it_mutates_an_existing_version() {
     new_test_ext().execute_with(|| {
         System::set_block_number(1);
-        assert_ok!(ProcessValidation::update_version(PROCESS_ID1));
-        assert_ok!(ProcessValidation::update_version(PROCESS_ID1));
-        assert_ok!(ProcessValidation::update_version(PROCESS_ID1));
+        assert_ok!(ProcessValidation::update_version(&PROCESS_ID1));
+        assert_ok!(ProcessValidation::update_version(&PROCESS_ID1));
+        assert_ok!(ProcessValidation::update_version(&PROCESS_ID1));
 
         let items: Vec<u32> = <VersionModel<Test>>::iter().map(|item| item.1.clone()).collect();
 
@@ -116,7 +116,7 @@ fn sets_versions_correctly_for_multiple_processes() {
         let mut ids = [PROCESS_ID2; 10].to_vec();
         ids.extend([PROCESS_ID1; 15].to_vec());
         ids.iter().for_each(|id| -> () {
-            assert_ok!(ProcessValidation::update_version(id.clone()));
+            assert_ok!(ProcessValidation::update_version(&id));
         });
 
         let id1_expected = TestEvent::ProcessValidation(ProcessCreated(

--- a/pallets/process-validation/src/tests/genesis.rs
+++ b/pallets/process-validation/src/tests/genesis.rs
@@ -1,0 +1,50 @@
+use super::*;
+use crate::binary_expression_tree::BooleanExpressionSymbol;
+use crate::binary_expression_tree::BooleanOperator;
+use crate::tests::ProcessIdentifier;
+use crate::{Process, ProcessModel, ProcessStatus, Restriction, VersionModel};
+use frame_support::bounded_vec;
+
+// -- fixtures --
+#[allow(dead_code)]
+const PROCESS_ID1: ProcessIdentifier = ProcessIdentifier::A;
+const PROCESS_ID2: ProcessIdentifier = ProcessIdentifier::B;
+
+use crate::GenesisConfig;
+
+#[test]
+fn genesis_with_valid_processes() {
+    new_test_ext_with_genesis(GenesisConfig::<Test> {
+      processes: vec![(
+        PROCESS_ID1,
+        bounded_vec![BooleanExpressionSymbol::Restriction(Restriction::Fail)]
+      ), (
+        PROCESS_ID2,
+        bounded_vec![BooleanExpressionSymbol::Restriction(Restriction::None)]
+      )]
+    }).execute_with(|| {
+        assert_eq!(<VersionModel<Test>>::get(PROCESS_ID1), 1u32);
+        assert_eq!(<ProcessModel<Test>>::get(PROCESS_ID1, 1u32), Process {
+          status: ProcessStatus::Enabled,
+          program: bounded_vec![BooleanExpressionSymbol::Restriction(Restriction::Fail)]
+        });
+        assert_eq!(<ProcessModel<Test>>::get(PROCESS_ID2, 1u32), Process {
+          status: ProcessStatus::Enabled,
+          program: bounded_vec![BooleanExpressionSymbol::Restriction(Restriction::None)]
+        });
+    });
+}
+
+#[test]
+#[should_panic]
+fn genesis_with_invalid_process() {
+    new_test_ext_with_genesis(GenesisConfig::<Test> {
+      processes: vec![(
+        PROCESS_ID1,
+        bounded_vec![BooleanExpressionSymbol::Restriction(Restriction::Fail)]
+      ), (
+        PROCESS_ID2,
+        bounded_vec![BooleanExpressionSymbol::Restriction(Restriction::None), BooleanExpressionSymbol::Op(BooleanOperator::And)]
+      )]
+    }).execute_with(|| {});
+}

--- a/pallets/process-validation/src/tests/genesis.rs
+++ b/pallets/process-validation/src/tests/genesis.rs
@@ -15,23 +15,33 @@ use crate::GenesisConfig;
 #[test]
 fn genesis_with_valid_processes() {
     new_test_ext_with_genesis(GenesisConfig::<Test> {
-      processes: vec![(
-        PROCESS_ID1,
-        bounded_vec![BooleanExpressionSymbol::Restriction(Restriction::Fail)]
-      ), (
-        PROCESS_ID2,
-        bounded_vec![BooleanExpressionSymbol::Restriction(Restriction::None)]
-      )]
-    }).execute_with(|| {
+        processes: vec![
+            (
+                PROCESS_ID1,
+                bounded_vec![BooleanExpressionSymbol::Restriction(Restriction::Fail)]
+            ),
+            (
+                PROCESS_ID2,
+                bounded_vec![BooleanExpressionSymbol::Restriction(Restriction::None)]
+            ),
+        ]
+    })
+    .execute_with(|| {
         assert_eq!(<VersionModel<Test>>::get(PROCESS_ID1), 1u32);
-        assert_eq!(<ProcessModel<Test>>::get(PROCESS_ID1, 1u32), Process {
-          status: ProcessStatus::Enabled,
-          program: bounded_vec![BooleanExpressionSymbol::Restriction(Restriction::Fail)]
-        });
-        assert_eq!(<ProcessModel<Test>>::get(PROCESS_ID2, 1u32), Process {
-          status: ProcessStatus::Enabled,
-          program: bounded_vec![BooleanExpressionSymbol::Restriction(Restriction::None)]
-        });
+        assert_eq!(
+            <ProcessModel<Test>>::get(PROCESS_ID1, 1u32),
+            Process {
+                status: ProcessStatus::Enabled,
+                program: bounded_vec![BooleanExpressionSymbol::Restriction(Restriction::Fail)]
+            }
+        );
+        assert_eq!(
+            <ProcessModel<Test>>::get(PROCESS_ID2, 1u32),
+            Process {
+                status: ProcessStatus::Enabled,
+                program: bounded_vec![BooleanExpressionSymbol::Restriction(Restriction::None)]
+            }
+        );
     });
 }
 
@@ -39,12 +49,19 @@ fn genesis_with_valid_processes() {
 #[should_panic]
 fn genesis_with_invalid_process() {
     new_test_ext_with_genesis(GenesisConfig::<Test> {
-      processes: vec![(
-        PROCESS_ID1,
-        bounded_vec![BooleanExpressionSymbol::Restriction(Restriction::Fail)]
-      ), (
-        PROCESS_ID2,
-        bounded_vec![BooleanExpressionSymbol::Restriction(Restriction::None), BooleanExpressionSymbol::Op(BooleanOperator::And)]
-      )]
-    }).execute_with(|| {});
+        processes: vec![
+            (
+                PROCESS_ID1,
+                bounded_vec![BooleanExpressionSymbol::Restriction(Restriction::Fail)]
+            ),
+            (
+                PROCESS_ID2,
+                bounded_vec![
+                    BooleanExpressionSymbol::Restriction(Restriction::None),
+                    BooleanExpressionSymbol::Op(BooleanOperator::And)
+                ]
+            ),
+        ]
+    })
+    .execute_with(|| {});
 }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dscp-node-runtime"
-version = "4.4.8"
+version = "4.5.0"
 authors = ["Digital Catapult <https://www.digicatapult.org.uk>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -59,11 +59,13 @@ frame-system-benchmarking = { version = "4.0.0-dev", default-features = false, g
 hex-literal = { version = "0.3.4", optional = true }
 
 # Local Dependencies
-pallet-doas = { version = '2.0.0', default-features = false, package = 'pallet-doas', path = '../pallets/doas' }
-pallet-simple-nft = { version = '4.0.0', default-features = false, package = 'pallet-simple-nft', path = '../pallets/simple-nft' }
-pallet-process-validation = { version = '3.1.1', default-features = false, package = 'pallet-process-validation', path = '../pallets/process-validation' }
-pallet-symmetric-key = { version = '2.0.1', default-features = false, package = 'pallet-symmetric-key', path = '../pallets/symmetric-key' }
-pallet-transaction-payment-free = { default-features = false, version = '2.0.0', package = 'pallet-transaction-payment-free', path = '../pallets/transaction-payment-free' }
+pallet-doas = { default-features = false, package = 'pallet-doas', path = '../pallets/doas' }
+pallet-simple-nft = { default-features = false, package = 'pallet-simple-nft', path = '../pallets/simple-nft' }
+pallet-process-validation = { default-features = false, package = 'pallet-process-validation', path = '../pallets/process-validation' }
+pallet-symmetric-key = { default-features = false, package = 'pallet-symmetric-key', path = '../pallets/symmetric-key' }
+pallet-transaction-payment-free = { default-features = false, package = 'pallet-transaction-payment-free', path = '../pallets/transaction-payment-free' }
+
+serde = { version = "1.0.137" }
 
 [build-dependencies]
 substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.32" }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -13,6 +13,8 @@ use frame_system::EnsureRoot;
 use pallet_grandpa::fg_primitives;
 use pallet_grandpa::{AuthorityId as GrandpaId, AuthorityList as GrandpaAuthorityList};
 use scale_info::TypeInfo;
+#[cfg(feature = "std")]
+use serde::{Deserialize, Serialize};
 use sp_api::impl_runtime_apis;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
@@ -68,6 +70,8 @@ pub type Index = u32;
 /// A hash of some data used by the chain.
 pub type Hash = sp_core::H256;
 
+pub mod types;
+
 /// Opaque types. These are used by the CLI to instantiate machinery that don't need to know
 /// the specifics of the runtime. They can then be made to be agnostic over specific formats
 /// of data like extrinsics, allowing for them to continue syncing the network through upgrades
@@ -97,7 +101,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("dscp"),
     impl_name: create_runtime_str!("dscp"),
     authoring_version: 1,
-    spec_version: 448,
+    spec_version: 450,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,
@@ -311,6 +315,7 @@ impl pallet_preimage::Config for Runtime {
 }
 
 #[derive(Encode, Decode, Clone, MaxEncodedLen, TypeInfo, PartialEq, Debug, Eq, Ord, PartialOrd)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub enum Role {
     Owner = 0,
     Customer = 1,
@@ -330,6 +335,8 @@ impl Default for Role {
 #[derive(Encode, Decode, Clone, MaxEncodedLen, TypeInfo, PartialEq, Debug, Eq, EnumDiscriminants)]
 #[strum_discriminants(derive(Encode, Decode, MaxEncodedLen, TypeInfo))]
 #[strum_discriminants(name(MetadataValueType))]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "std", strum_discriminants(derive(Serialize, Deserialize)))]
 pub enum MetadataValue<TokenId> {
     File(Hash),
     Literal(BoundedVec<u8, ConstU32<32>>),

--- a/runtime/src/types.rs
+++ b/runtime/src/types.rs
@@ -1,0 +1,1 @@
+pub use pallet_process_validation::{BooleanExpressionSymbol, BooleanOperator, Restriction};


### PR DESCRIPTION
~Draft pending merging of #109~

This PR adds genesis configuration for setting up default process-validation processes at chain initialisation. For testnet chains this will defaut to a single process called `default` which attributes no restrictions. The intent then is a deployment would update this with process flows more appropriate for that use case
