### PR TITLE
Adds MatchInputIdOutputMetadataValue restriction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1579,7 +1579,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "dscp-node"
-version = "4.6.0"
+version = "4.6.1"
 dependencies = [
  "bs58",
  "clap",
@@ -1623,7 +1623,7 @@ dependencies = [
 
 [[package]]
 name = "dscp-node-runtime"
-version = "4.5.3"
+version = "4.5.4"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",
@@ -1671,7 +1671,7 @@ dependencies = [
 
 [[package]]
 name = "dscp-pallet-traits"
-version = "3.0.1"
+version = "3.1.0"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4663,7 +4663,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-process-validation"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "dscp-pallet-traits",
  "frame-benchmarking",
@@ -4718,7 +4718,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-simple-nft"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "dscp-pallet-traits",
  "frame-benchmarking",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -6,7 +6,7 @@ edition = '2021'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/dscp-node/'
 name = 'dscp-node'
-version = '4.6.0'
+version = '4.6.1'
 
 [[bin]]
 name = 'dscp-node'

--- a/pallets/process-validation/Cargo.toml
+++ b/pallets/process-validation/Cargo.toml
@@ -5,7 +5,7 @@ edition = '2021'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/dscp-node/'
 name = 'pallet-process-validation'
-version = "3.2.1"
+version = "3.3.0"
 
 
 [package.metadata.docs.rs]

--- a/pallets/process-validation/src/tests.rs
+++ b/pallets/process-validation/src/tests.rs
@@ -103,6 +103,7 @@ impl pallet_process_validation::Config for Test {
     type DisableProcessOrigin = system::EnsureRoot<u64>;
     type WeightInfo = ();
 
+    type TokenId = u128;
     type RoleKey = u32;
     type TokenMetadataKey = u32;
     type TokenMetadataValue = u128;

--- a/pallets/process-validation/src/tests/validate_process.rs
+++ b/pallets/process-validation/src/tests/validate_process.rs
@@ -130,6 +130,7 @@ fn it_succeeds_when_all_restrictions_succeed() {
             },
             &0u64,
             &vec![ProcessIO {
+                id: 1u128,
                 roles: token_roles,
                 metadata: BTreeMap::new(),
                 parent_index: None
@@ -165,6 +166,7 @@ fn it_fails_when_one_restrictions_fails() {
             },
             &0u64,
             &vec![ProcessIO {
+                id: 1u128,
                 roles: token_roles,
                 metadata: BTreeMap::new(),
                 parent_index: None
@@ -202,6 +204,7 @@ fn it_succeeds_wth_complex_tree() {
             },
             &1u64,
             &vec![ProcessIO {
+                id: 1u128,
                 roles: token_roles,
                 metadata: BTreeMap::new(),
                 parent_index: None
@@ -239,6 +242,7 @@ fn it_fails_wth_complex_tree() {
             },
             &1u64,
             &vec![ProcessIO {
+                id: 1u128,
                 roles: token_roles,
                 metadata: BTreeMap::new(),
                 parent_index: None

--- a/pallets/simple-nft/Cargo.toml
+++ b/pallets/simple-nft/Cargo.toml
@@ -5,7 +5,7 @@ edition = '2021'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/dscp-node/'
 name = 'pallet-simple-nft'
-version = "4.0.1"
+version = "4.0.2"
 
 
 [package.metadata.docs.rs]

--- a/pallets/simple-nft/src/mock.rs
+++ b/pallets/simple-nft/src/mock.rs
@@ -108,9 +108,9 @@ impl Default for ProcessIdentifier {
 pub struct MockProcessValidator {}
 
 type TestProcessId = ProcessFullyQualifiedId<ProcessIdentifier, u32>;
-type TestProcessIO = ProcessIO<u64, Role, u64, MetadataValue<u64>>;
+type TestProcessIO = ProcessIO<u64, u64, Role, u64, MetadataValue<u64>>;
 
-impl ProcessValidator<u64, Role, u64, MetadataValue<u64>> for MockProcessValidator {
+impl ProcessValidator<u64, u64, Role, u64, MetadataValue<u64>> for MockProcessValidator {
     type ProcessIdentifier = ProcessIdentifier;
     type ProcessVersion = u32;
 

--- a/pallets/traits/Cargo.toml
+++ b/pallets/traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dscp-pallet-traits"
-version = "3.0.1"
+version = "3.1.0"
 edition = "2021"
 authors = ['Digital Catapult <https://www.digicatapult.org.uk>']
 license = 'Apache-2.0'

--- a/pallets/traits/src/lib.rs
+++ b/pallets/traits/src/lib.rs
@@ -9,7 +9,8 @@ use scale_info::TypeInfo;
 use sp_std::collections::btree_map::BTreeMap;
 use sp_std::prelude::*;
 
-pub struct ProcessIO<AccountId, RoleKey: Ord, TokenMetadataKey: Ord, TokenMetadataValue> {
+pub struct ProcessIO<IoIdentifier, AccountId, RoleKey: Ord, TokenMetadataKey: Ord, TokenMetadataValue> {
+    pub id: IoIdentifier,
     pub roles: BTreeMap<RoleKey, AccountId>,
     pub metadata: BTreeMap<TokenMetadataKey, TokenMetadataValue>,
     pub parent_index: Option<u32>
@@ -24,8 +25,9 @@ pub struct ProcessFullyQualifiedId<
     pub version: ProcessVersion
 }
 
-pub trait ProcessValidator<A, R, T, V>
+pub trait ProcessValidator<I, A, R, T, V>
 where
+    I: Parameter,
     A: Parameter,
     R: Parameter + Ord,
     T: Parameter + Ord,
@@ -37,13 +39,14 @@ where
     fn validate_process(
         id: ProcessFullyQualifiedId<Self::ProcessIdentifier, Self::ProcessVersion>,
         sender: &A,
-        inputs: &Vec<ProcessIO<A, R, T, V>>,
-        outputs: &Vec<ProcessIO<A, R, T, V>>
+        inputs: &Vec<ProcessIO<I, A, R, T, V>>,
+        outputs: &Vec<ProcessIO<I, A, R, T, V>>
     ) -> bool;
 }
 
-impl<A, R, T, V> ProcessValidator<A, R, T, V> for ()
+impl<I, A, R, T, V> ProcessValidator<I, A, R, T, V> for ()
 where
+    I: Parameter,
     A: Parameter,
     R: Parameter + Ord,
     T: Parameter + Ord,
@@ -55,8 +58,8 @@ where
     fn validate_process(
         _id: ProcessFullyQualifiedId<Self::ProcessIdentifier, Self::ProcessVersion>,
         _sender: &A,
-        _inputs: &Vec<ProcessIO<A, R, T, V>>,
-        _outputs: &Vec<ProcessIO<A, R, T, V>>
+        _inputs: &Vec<ProcessIO<I, A, R, T, V>>,
+        _outputs: &Vec<ProcessIO<I, A, R, T, V>>
     ) -> bool {
         true
     }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dscp-node-runtime"
-version = "4.5.3"
+version = "4.5.4"
 authors = ["Digital Catapult <https://www.digicatapult.org.uk>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -101,7 +101,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("dscp"),
     impl_name: create_runtime_str!("dscp"),
     authoring_version: 1,
-    spec_version: 453,
+    spec_version: 454,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,
@@ -359,6 +359,15 @@ impl Default for MetadataValueType {
     }
 }
 
+impl<T: PartialEq> PartialEq<T> for MetadataValue<T> {
+    fn eq(&self, rhs: &T) -> bool {
+        match self {
+            MetadataValue::<T>::TokenId(v) => v == rhs,
+            _ => false
+        }
+    }
+}
+
 type TokenId = u128;
 type TokenMetadataKey = BoundedVec<u8, ConstU32<32>>;
 type TokenMetadataValue = MetadataValue<TokenId>;
@@ -387,6 +396,7 @@ impl pallet_process_validation::Config for Runtime {
     type CreateProcessOrigin = MoreThanTwoMembers;
     type DisableProcessOrigin = MoreThanTwoMembers;
     type WeightInfo = pallet_process_validation::weights::SubstrateWeight<Runtime>;
+    type TokenId = TokenId;
     type RoleKey = Role;
     type TokenMetadataKey = TokenMetadataKey;
     type TokenMetadataValue = TokenMetadataValue;


### PR DESCRIPTION
Enforce that a metadata value on a specified metadata key on an output at a specified index matches the id of an input at a specified index.

For L3 this will allow us to enforce that on final acceptance a match can only finalise for the correct demands.

Note this also deals with the index out-of-bounds bug but only for this new Restriction