### PR TITLE
Ignore `jsonrpsee` for Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,11 @@
 {
-	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": ["github>digicatapult/renovate-config"]
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>digicatapult/renovate-config"],
+  "cargo": {
+    "packageRules": [
+      {
+        "excludePackageNames": ["jsonrpsee"]
+      }
+    ]
+  }
 }


### PR DESCRIPTION
Updating `jsonrpsee` is causing our renovate auto-update to fail https://github.com/digicatapult/dscp-node/pull/123