### PR TITLE
Replace uses of `veritable` with `dscp` and add a little more context to the introductory sentence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Veritable node
+# DSCP node
 
-This repository contains the source code for the blockchain nodes used in the Veritable project. The structure and code is heavily based on [Substrate Node Template](https://github.com/substrate-developer-hub/substrate-node-template). To use this repository, it's important to understand the [key concepts](https://substrate.dev/docs/en/) of Substrate, such as `FRAME`, `runtime`, `extrinsics` and `transaction weight`.
+This repository contains the source code for the blockchain nodes used in a number of Digital Catapult projects that address Distributed System challenges. The structure and code is heavily based on [Substrate Node Template](https://github.com/substrate-developer-hub/substrate-node-template). To use this repository, it's important to understand the [key concepts](https://substrate.dev/docs/en/) of Substrate, such as `FRAME`, `runtime`, `extrinsics` and `transaction weight`.
 
-For more on governance visit [veritable-documentation](https://github.com/digicatapult/dscp-documentation/blob/main/docs/governance.md).
+For more on governance visit [dscp-documentation](https://github.com/digicatapult/dscp-documentation/blob/main/docs/governance.md).
 
 ## Getting started
 


### PR DESCRIPTION
---
name: Bug report
about: Create a report to help us improve
---

<!--

Have you read DSCP's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/digicatapult/dscp-node/.github/blob/main/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [X] Put an X between the brackets on this line if you have done all of the following:
  - Checked the FAQs for common solutions: <https://github.com/digicatapult/dscp-node/blob/main/CONTRIBUTING.md/#FAQs>
  - Checked that your issue isn't already filed: <https://github.com/issues?utf8=✓&q=is%3Aissue+user%3Adscp-node>

### Description

Repository named `dscp`, README makes reference to `veritable`

### Steps to Reproduce

1. <!-- First Step -->
2. <!-- Second Step -->
3. <!-- and so on… -->

**Expected behaviour:**

README refers to `dscp`

**Actual behaviour:**

README refers to `veritable` in places

**Reproduces how often:**

<!-- What percentage of the time does it reproduce? -->

### Versions

<!-- You can get this information from copy and pasting the version on the home page or via package.json. Also, please include the OS and what version of the OS you're running. -->

### Additional Information

<!-- Any additional information, configuration or data that might be necessary to reproduce the issue. -->