### PR TITLE
Allow equality between different token types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1703,7 +1703,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "dscp-lang"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "dscp-runtime-types",

--- a/tools/lang/Cargo.toml
+++ b/tools/lang/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dscp-lang"
 authors = ['Digital Catapult <https://www.digicatapult.org.uk>']
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [dependencies]

--- a/tools/lang/src/compiler/condition_transform.rs
+++ b/tools/lang/src/compiler/condition_transform.rs
@@ -274,22 +274,6 @@ pub fn transform_condition_to_program(
                         }),
                     }?;
 
-                    if input.arg.token_type.value != output.arg.token_type.value {
-                        return Err(CompilationError {
-                            stage: crate::compiler::CompilationStage::GenerateRestrictions,
-                            exit_code: exitcode::DATAERR,
-                            inner: PestError::new_from_span(
-                                ErrorVariant::CustomError {
-                                    message: format!(
-                                        "Invalid comparison between token type {} and {}",
-                                        input.arg.token_type.value, output.arg.token_type.value
-                                    ),
-                                },
-                                span,
-                            ),
-                        });
-                    }
-
                     let original_key = TokenMetadataKey::try_from(ORIGINAL_ID_KEY.to_vec()).unwrap();
                     let result = vec![
                         BooleanExpressionSymbol::Restriction(Restriction::MatchInputOutputMetadataValue {


### PR DESCRIPTION
Removes an assertion on `TokenToken` (e.g. `token_a == token_b`) equality checks that the two tokens are the same type. This is not a requirement in all use cases