### PR TITLE
Integrate dscp-lang into dscp-node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1703,7 +1703,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "dscp-lang"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "clap",
  "dscp-runtime-types",
@@ -1713,14 +1713,16 @@ dependencies = [
  "pest_derive",
  "serde",
  "serde_json",
+ "thiserror",
 ]
 
 [[package]]
 name = "dscp-node"
-version = "9.1.2"
+version = "9.1.3"
 dependencies = [
  "bs58",
  "clap",
+ "dscp-lang",
  "dscp-node-runtime",
  "frame-benchmarking",
  "frame-benchmarking-cli",
@@ -8714,18 +8716,18 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1718,7 +1718,7 @@ dependencies = [
 
 [[package]]
 name = "dscp-node"
-version = "9.1.3"
+version = "9.2.0"
 dependencies = [
  "bs58",
  "clap",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -6,7 +6,7 @@ edition = '2021'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/dscp-node/'
 name = 'dscp-node'
-version = '9.1.2'
+version = '9.1.3'
 
 [[bin]]
 name = 'dscp-node'
@@ -59,6 +59,7 @@ frame-benchmarking-cli = { version = "4.0.0-dev", git = "https://github.com/pari
 # Local Dependencies
 dscp-node-runtime = { path = '../runtime' }
 pallet-transaction-payment-free = { default-features = false, path = '../pallets/transaction-payment-free' }
+dscp-lang = { path = '../tools/lang' }
 
 # CLI-specific dependencies
 try-runtime-cli = { version = "0.10.0-dev", optional = true, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -6,7 +6,7 @@ edition = '2021'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/dscp-node/'
 name = 'dscp-node'
-version = '9.1.3'
+version = '9.2.0'
 
 [[bin]]
 name = 'dscp-node'

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -1,3 +1,4 @@
+use dscp_lang::cli::Cli as LangCli;
 use sc_cli::RunCmd;
 
 #[derive(Debug, clap::Parser)]
@@ -43,4 +44,7 @@ pub enum Subcommand {
 
     /// Db meta columns information.
     ChainInfo(sc_cli::ChainInfoCmd),
+
+    /// DSCP language tool for parsing and compiling dscp files.
+    Lang(LangCli),
 }

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -181,6 +181,9 @@ pub fn run() -> sc_cli::Result<()> {
             let runner = cli.create_runner(cmd)?;
             runner.sync_run(|config| cmd.run::<Block>(&config))
         }
+        Some(Subcommand::Lang(cmd)) => cmd
+            .run()
+            .map_err(|lang_err| sc_cli::Error::Application(Box::new(lang_err))),
         None => {
             let runner = cli.create_runner(&cli.run)?;
             runner

--- a/tools/lang/Cargo.toml
+++ b/tools/lang/Cargo.toml
@@ -1,8 +1,16 @@
 [package]
 name = "dscp-lang"
 authors = ['Digital Catapult <https://www.digicatapult.org.uk>']
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
+
+[lib]
+name = "dscp_lang"
+path = "src/lib.rs"
+
+[[bin]]
+name = "dscp-lang"
+path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4.4.6", features = ["derive"] }
@@ -13,3 +21,4 @@ pest_derive = "2.6"
 dscp-runtime-types = { path = '../../runtime/types' }
 serde = { version = "1.0.189" }
 serde_json = { version = "1.0.107" }
+thiserror = { version = "1.0.50" }

--- a/tools/lang/src/errors.rs
+++ b/tools/lang/src/errors.rs
@@ -28,7 +28,7 @@ impl fmt::Display for CompilationStage {
     }
 }
 
-#[derive(PartialEq)]
+#[derive(PartialEq, thiserror::Error)]
 pub struct CompilationError {
     pub(crate) stage: CompilationStage,
     pub(crate) exit_code: i32,

--- a/tools/lang/src/lib.rs
+++ b/tools/lang/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod cli;
+
+mod ast;
+mod compiler;
+mod convert;
+mod errors;
+mod parser;

--- a/tools/lang/src/main.rs
+++ b/tools/lang/src/main.rs
@@ -1,10 +1,9 @@
-pub mod ast;
-pub mod compiler;
-pub mod errors;
-pub mod parser;
-
+mod ast;
 mod cli;
+mod compiler;
 mod convert;
+mod errors;
+mod parser;
 
 fn main() -> ! {
     let result = cli::Cli::new().run();


### PR DESCRIPTION
Adds dscp-lang as a subcommand of dscp-node under lang. This involved a number of changes:

- made `dscp-lang` both a lib and a bin
- update `dscp-node` to include `lang` subcommand
- update exports from dscp-lang to have necessary visibility and trait impls

In addition this includes:

- update output from `lang build` command when passing `-v` to actually be verbose and more useful