### PR TITLE
Reorganise deps into workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1709,7 +1709,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "dscp-lang"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "clap",
  "dscp-runtime-types",
@@ -1724,7 +1724,7 @@ dependencies = [
 
 [[package]]
 name = "dscp-node"
-version = "9.3.0"
+version = "9.3.1"
 dependencies = [
  "async-trait",
  "bs58",
@@ -1773,7 +1773,7 @@ dependencies = [
 
 [[package]]
 name = "dscp-node-runtime"
-version = "9.3.0"
+version = "9.3.1"
 dependencies = [
  "dscp-runtime-types",
  "frame-benchmarking",
@@ -1815,14 +1815,12 @@ dependencies = [
  "sp-std",
  "sp-transaction-pool",
  "sp-version",
- "strum",
- "strum_macros",
  "substrate-wasm-builder",
 ]
 
 [[package]]
 name = "dscp-pallet-traits"
-version = "3.2.3"
+version = "3.2.4"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -1832,7 +1830,7 @@ dependencies = [
 
 [[package]]
 name = "dscp-runtime-types"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "frame-support",
  "pallet-process-validation",
@@ -4882,7 +4880,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-doas"
-version = "2.0.3"
+version = "2.0.4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4971,7 +4969,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-process-validation"
-version = "3.4.3"
+version = "3.4.4"
 dependencies = [
  "dscp-pallet-traits",
  "frame-benchmarking",
@@ -5040,7 +5038,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-symmetric-key"
-version = "2.0.3"
+version = "2.0.4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5092,7 +5090,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment-free"
-version = "2.0.2"
+version = "2.0.3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5137,7 +5135,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-utxo-nft"
-version = "6.1.1"
+version = "6.1.2"
 dependencies = [
  "dscp-pallet-traits",
  "frame-benchmarking",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,103 @@ panic = 'unwind'
 members = ['node', 'pallets/*', 'runtime', 'runtime/types', 'tools/*']
 resolver = "2"
 
+[workspace.dependencies]
+##############################
+# non-substrate dependencies #
+##############################
+serde = { version = "1.0.159", default-features = false }
+serde_json = "1.0.95"
+jsonrpsee = { version = "0.16.2", features = ["server"] }
+clap = { version = "4.4.6", features = ["derive"] }
+futures = { version = "0.3.27", features = ["thread-pool"] }
+bs58 = "0.4.0"
+async-trait = "0.1.57"
+hex-literal = "0.3.4"
+exitcode = "1.1.2"
+lazy_static = "1.4.0"
+pest = "2.6"
+pest_derive = "2.6"
+thiserror = "1.0.50"
+
+####################################
+# substrate dependencies crates.io #
+####################################
+scale-info = { version = "2.5.0", default-features = false, features = [
+  "derive",
+] }
+parity-scale-codec = { version = "3.4.0", default-features = false, features = [
+  "derive",
+] }
+
+###################################
+# substrate dependencies from git #
+###################################
+
+# Runtime component dependencies
+frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+frame-system = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+frame-benchmarking = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sp-io = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sp-std = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sp-core = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+frame-support-test = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+pallet-scheduler = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+pallet-balances = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+pallet-babe = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+pallet-grandpa = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+pallet-sudo = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+pallet-timestamp = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+pallet-transaction-payment-rpc-runtime-api = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+frame-executive = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sp-api = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sp-block-builder = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sp-consensus-babe = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sp-consensus-grandpa = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sp-inherents = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sp-offchain = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sp-session = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sp-transaction-pool = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sp-version = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+frame-try-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+pallet-collective = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+pallet-membership = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+pallet-node-authorization = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+pallet-preimage = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+pallet-transaction-payment-rpc = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+frame-system-rpc-runtime-api = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+frame-system-benchmarking = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+
+# node dependencies
+sc-cli = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sc-executor = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sc-service = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sc-telemetry = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sc-keystore = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sc-transaction-pool = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sc-transaction-pool-api = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sc-consensus-manual-seal = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sc-consensus-babe = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sc-consensus-babe-rpc = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sp-consensus = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sc-consensus = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sc-consensus-grandpa = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sc-client-api = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sp-timestamp = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sp-keyring = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sp-keystore = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sc-rpc = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sc-rpc-api = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sp-blockchain = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sc-basic-authorship = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+substrate-frame-rpc-system = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+frame-benchmarking-cli = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+try-runtime-cli = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+
+# build dependencies
+substrate-wasm-builder = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+substrate-build-script-utils = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+
 [profile.production]
 inherits = "release"
 lto = true

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -6,7 +6,7 @@ edition = '2021'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/dscp-node/'
 name = 'dscp-node'
-version = '9.3.0'
+version = '9.3.1'
 
 [[bin]]
 name = 'dscp-node'
@@ -15,48 +15,48 @@ name = 'dscp-node'
 targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
-clap = { version = "4.4.6", features = ["derive"] }
-futures = { version = "0.3.27", features = ["thread-pool"] }
-bs58 = "0.4.0"
-async-trait = "0.1.57"
+clap = { workspace = true }
+futures = { workspace = true }
+bs58 = { workspace = true }
+async-trait = { workspace = true }
 
-sc-cli = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-core = { version = "7.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sc-executor = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sc-service = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sc-telemetry = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sc-keystore = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sc-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sc-transaction-pool-api = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sc-consensus-manual-seal = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sc-consensus-babe = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sc-consensus-babe-rpc = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-consensus-babe = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-consensus = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sc-consensus = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sc-consensus-grandpa = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-consensus-grandpa = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sc-client-api = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-runtime = { version = "7.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-timestamp = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-inherents = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-keyring = { version = "7.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-keystore = { version = "0.13.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-frame-system = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sc-cli = { workspace = true }
+sp-core = { workspace = true }
+sc-executor = { workspace = true }
+sc-service = { workspace = true }
+sc-telemetry = { workspace = true }
+sc-keystore = { workspace = true }
+sc-transaction-pool = { workspace = true }
+sc-transaction-pool-api = { workspace = true }
+sc-consensus-manual-seal = { workspace = true }
+sc-consensus-babe = { workspace = true }
+sc-consensus-babe-rpc = { workspace = true }
+sp-consensus-babe = { workspace = true }
+sp-consensus = { workspace = true }
+sc-consensus = { workspace = true }
+sc-consensus-grandpa = { workspace = true }
+sp-consensus-grandpa = { workspace = true }
+sc-client-api = { workspace = true }
+sp-runtime = { workspace = true }
+sp-timestamp = { workspace = true }
+sp-inherents = { workspace = true }
+sp-keyring = { workspace = true }
+sp-keystore = { workspace = true }
+frame-system = { workspace = true }
 
 # These dependencies are used for the node template's RPCs
-jsonrpsee = { version = "0.16.2", features = ["server"] }
-sc-rpc = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-api = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sc-rpc-api = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-block-builder = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sc-basic-authorship = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-substrate-frame-rpc-system = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+jsonrpsee = { workspace = true }
+sc-rpc = { workspace = true }
+sp-api = { workspace = true }
+sc-rpc-api = { workspace = true }
+sp-blockchain = { workspace = true }
+sp-block-builder = { workspace = true }
+sc-basic-authorship = { workspace = true }
+substrate-frame-rpc-system = { workspace = true }
 
 # These dependencies are used for runtime benchmarking
-frame-benchmarking = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-frame-benchmarking-cli = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+frame-benchmarking = { workspace = true }
+frame-benchmarking-cli = { workspace = true }
 
 # Local Dependencies
 dscp-node-runtime = { path = '../runtime' }
@@ -64,12 +64,12 @@ pallet-transaction-payment-free = { default-features = false, path = '../pallets
 dscp-lang = { path = '../tools/lang' }
 
 # CLI-specific dependencies
-try-runtime-cli = { version = "0.10.0-dev", optional = true, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+try-runtime-cli = { workspace = true, optional = true }
 
-pallet-transaction-payment-rpc = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+pallet-transaction-payment-rpc = { workspace = true }
 
 [build-dependencies]
-substrate-build-script-utils = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+substrate-build-script-utils = { workspace = true }
 
 [features]
 default = []

--- a/pallets/doas/Cargo.toml
+++ b/pallets/doas/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "pallet-doas"
-version = "2.0.3"
-authors = ["Digital Catapult <https://www.digicatapult.org.uk>", "Parity Technologies <admin@parity.io>"]
+version = "2.0.4"
+authors = [
+	"Digital Catapult <https://www.digicatapult.org.uk>",
+	"Parity Technologies <admin@parity.io>",
+]
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/digicatapult/dscp-node/"
@@ -12,24 +15,24 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-serde = { version = "1.0.159", optional = true }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
-codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
-frame-support = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-frame-system = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-frame-benchmarking = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", optional = true , branch = "polkadot-v0.9.42" }
-sp-runtime = { default-features = false, version = "7.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-io = { default-features = false, version = "7.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-std = { default-features = false, version = "5.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+frame-benchmarking = { workspace = true, optional = true }
+serde = { workspace = true, optional = true }
+scale-info = { workspace = true }
+parity-scale-codec = { workspace = true }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+sp-runtime = { workspace = true }
+sp-io = { workspace = true }
+sp-std = { workspace = true }
 
 [dev-dependencies]
-sp-core = { default-features = false, version = "7.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sp-core = { workspace = true }
 
 [features]
 default = ["std"]
 std = [
 	"serde",
-	"codec/std",
+	"parity-scale-codec/std",
 	"sp-std/std",
 	"sp-io/std",
 	"sp-runtime/std",

--- a/pallets/process-validation/Cargo.toml
+++ b/pallets/process-validation/Cargo.toml
@@ -5,31 +5,32 @@ edition = '2021'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/dscp-node/'
 name = 'pallet-process-validation'
-version = "3.4.3"
+version = "3.4.4"
 
 
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
-serde = { version = "1.0.159", optional = true }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
-codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
+serde = { workspace = true, optional = true }
+scale-info = { workspace = true }
+parity-scale-codec = { workspace = true }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+frame-benchmarking = { workspace = true, optional = true }
+sp-runtime = { workspace = true }
+sp-io = { workspace = true }
+sp-std = { workspace = true }
+
 dscp-pallet-traits = { default-features = false, path = '../traits' }
-frame-support = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-frame-system = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-frame-benchmarking = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", optional = true , branch = "polkadot-v0.9.42" }
-sp-runtime = { default-features = false, version = "7.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-io = { default-features = false, version = "7.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-std = { default-features = false, version = "5.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 
 [dev-dependencies]
-sp-core = { default-features = false, version = "7.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sp-core = { workspace = true }
 
 [features]
 default = ['std']
 std = [
-    'codec/std',
+    'parity-scale-codec/std',
     'frame-support/std',
     'frame-system/std',
     'frame-benchmarking/std',

--- a/pallets/process-validation/src/binary_expression_tree.rs
+++ b/pallets/process-validation/src/binary_expression_tree.rs
@@ -1,4 +1,4 @@
-use codec::{Decode, Encode, MaxEncodedLen};
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};

--- a/pallets/process-validation/src/lib.rs
+++ b/pallets/process-validation/src/lib.rs
@@ -1,8 +1,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{traits::Get, BoundedVec, Parameter, RuntimeDebug};
 pub use pallet::*;
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 use sp_runtime::traits::{AtLeast32Bit, One};
 use sp_std::prelude::*;
@@ -97,9 +97,9 @@ pub use weights::WeightInfo;
 pub mod pallet {
 
     use super::*;
-    use codec::MaxEncodedLen;
     use frame_support::{pallet_prelude::*, BoundedVec};
     use frame_system::pallet_prelude::*;
+    use parity_scale_codec::MaxEncodedLen;
 
     /// The pallet's configuration trait.
     #[pallet::config]

--- a/pallets/process-validation/src/restrictions.rs
+++ b/pallets/process-validation/src/restrictions.rs
@@ -1,9 +1,9 @@
 // This file contains the different types of restrictions that can be evaluated during
 // a call to `validate_process`
 
-use codec::{Decode, Encode, MaxEncodedLen};
 use dscp_pallet_traits::ProcessIO;
 use frame_support::Parameter;
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};

--- a/pallets/process-validation/src/tests.rs
+++ b/pallets/process-validation/src/tests.rs
@@ -1,12 +1,12 @@
 // Creating mock runtime here
 
 use crate as pallet_process_validation;
-use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{
     parameter_types,
     traits::{ConstU32, ConstU64, GenesisBuild},
 };
 use frame_system as system;
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};

--- a/pallets/symmetric-key/Cargo.toml
+++ b/pallets/symmetric-key/Cargo.toml
@@ -5,32 +5,32 @@ edition = '2021'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/dscp-node/'
 name = 'pallet-symmetric-key'
-version = "2.0.3"
+version = "2.0.4"
 
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
-codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
-frame-support = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-frame-system = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-frame-benchmarking = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", optional = true , branch = "polkadot-v0.9.42" }
-sp-runtime = { default-features = false, version = "7.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-io = { default-features = false, version = "7.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-std = { default-features = false, version = "5.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+scale-info = { workspace = true }
+parity-scale-codec = { workspace = true }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+frame-benchmarking = { workspace = true, optional = true }
+sp-runtime = { workspace = true }
+sp-io = { workspace = true }
+sp-std = { workspace = true }
 
 [dev-dependencies]
-serde = { version = "1.0.159" }
-frame-support-test = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-pallet-scheduler = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-core = { default-features = false, version = "7.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+serde = { workspace = true }
+frame-support-test = { workspace = true }
+pallet-scheduler = { workspace = true }
+sp-core = { workspace = true }
 
 
 [features]
 default = ['std']
 std = [
-    'codec/std',
+    'parity-scale-codec/std',
     'frame-support/std',
     'frame-system/std',
     'frame-benchmarking/std',

--- a/pallets/symmetric-key/src/tests.rs
+++ b/pallets/symmetric-key/src/tests.rs
@@ -92,7 +92,7 @@ impl pallet_scheduler::Config for Test {
 
 pub struct TestRandomness<Test>(sp_std::marker::PhantomData<Test>);
 
-impl<Output: codec::Decode + Default, Test> frame_support::traits::Randomness<Output, Test::BlockNumber>
+impl<Output: parity_scale_codec::Decode + Default, Test> frame_support::traits::Randomness<Output, Test::BlockNumber>
     for TestRandomness<Test>
 where
     Test: frame_system::Config,

--- a/pallets/traits/Cargo.toml
+++ b/pallets/traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dscp-pallet-traits"
-version = "3.2.3"
+version = "3.2.4"
 edition = "2021"
 authors = ['Digital Catapult <https://www.digicatapult.org.uk>']
 license = 'Apache-2.0'
@@ -8,14 +8,11 @@ repository = 'https://github.com/digicatapult/dscp-node/'
 description = "Common pallet traits for the dscp-node"
 
 [dependencies]
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
-codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
-sp-std = { default-features = false, version = "5.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-frame-support = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+scale-info = { workspace = true }
+parity-scale-codec = { workspace = true }
+sp-std = { workspace = true }
+frame-support = { workspace = true }
 
 [features]
 default = ['std']
-std = [
-  'sp-std/std',
-  'frame-support/std',
-]
+std = ['sp-std/std', 'frame-support/std']

--- a/pallets/traits/src/lib.rs
+++ b/pallets/traits/src/lib.rs
@@ -1,8 +1,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use codec::{Decode, Encode};
 use frame_support::weights::Weight;
 use frame_support::{Parameter, RuntimeDebug};
+use parity_scale_codec::{Decode, Encode};
 
 use frame_support::codec::MaxEncodedLen;
 use frame_support::sp_runtime::traits::AtLeast32Bit;

--- a/pallets/transaction-payment-free/Cargo.toml
+++ b/pallets/transaction-payment-free/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-transaction-payment-free"
-version = "2.0.2"
+version = "2.0.3"
 authors = [
 	"Digital Catapult <https://www.digicatapult.org.uk>",
 	"Parity Technologies <admin@parity.io>",
@@ -15,31 +15,31 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
-codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
-serde = { version = "1.0.159", optional = true }
-sp-std = { default-features = false, version = "5.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-runtime = { default-features = false, version = "7.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-frame-support = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-frame-system = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-io = { default-features = false, version = "7.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-core = { default-features = false, version = "7.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+scale-info = { workspace = true }
+parity-scale-codec = { workspace = true }
+serde = { workspace = true, optional = true }
+sp-std = { workspace = true }
+sp-runtime = { workspace = true }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+sp-io = { workspace = true }
+sp-core = { workspace = true }
 
 [dev-dependencies]
-pallet-balances = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-serde_json = "1.0.95"
+pallet-balances = { workspace = true }
+serde_json = { workspace = true }
 
 [features]
 default = ["std"]
 std = [
 	"serde",
-	"codec/std",
+	"parity-scale-codec/std",
 	"sp-std/std",
 	"sp-runtime/std",
 	"frame-support/std",
 	"frame-system/std",
 	"sp-io/std",
 	"sp-core/std",
-	"pallet-balances/std"
+	"pallet-balances/std",
 ]
 try-runtime = ["frame-support/try-runtime"]

--- a/pallets/transaction-payment-free/src/lib.rs
+++ b/pallets/transaction-payment-free/src/lib.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use codec::{Decode, Encode};
 use frame_support::dispatch::{DispatchInfo, PostDispatchInfo};
+use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use sp_std::prelude::*;
 

--- a/pallets/transaction-payment-free/src/payment.rs
+++ b/pallets/transaction-payment-free/src/payment.rs
@@ -1,9 +1,9 @@
 use crate::Config;
-use codec::FullCodec;
 use frame_support::{
     traits::{Currency, Imbalance, OnUnbalanced},
     unsigned::TransactionValidityError,
 };
+use parity_scale_codec::FullCodec;
 use sp_runtime::{
     traits::{AtLeast32BitUnsigned, DispatchInfoOf, MaybeSerializeDeserialize, Zero},
     transaction_validity::InvalidTransaction,

--- a/pallets/utxo-nft/Cargo.toml
+++ b/pallets/utxo-nft/Cargo.toml
@@ -5,37 +5,34 @@ edition = '2021'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/dscp-node/'
 name = 'pallet-utxo-nft'
-version = "6.1.1"
+version = "6.1.2"
 
 
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
-scale-info = { version = "2.5.0", default-features = false, features = [
-    "derive",
-] }
-codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = [
-    "derive",
-] }
+sp-core = { workspace = true, optional = true }
+scale-info = { workspace = true }
+parity-scale-codec = { workspace = true }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+sp-runtime = { workspace = true }
+sp-io = { workspace = true }
+sp-std = { workspace = true }
+frame-benchmarking = { workspace = true, optional = true }
+
 dscp-pallet-traits = { default-features = false, path = '../traits' }
-frame-support = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-frame-system = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-frame-benchmarking = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", optional = true, branch = "polkadot-v0.9.42" }
-sp-runtime = { default-features = false, version = "7.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-io = { default-features = false, version = "7.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-std = { default-features = false, version = "5.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-core = { default-features = false, version = "7.0.0", git = "https://github.com/paritytech/substrate.git", optional = true, branch = "polkadot-v0.9.42" }
 
 [dev-dependencies]
-serde = { version = "1.0.159" }
-sp-core = { default-features = false, version = "7.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+serde = { workspace = true }
+sp-core = { workspace = true }
 
 
 [features]
 default = ['std']
 std = [
-    'codec/std',
+    'parity-scale-codec/std',
     'frame-support/std',
     'frame-system/std',
     'frame-benchmarking/std',

--- a/pallets/utxo-nft/src/graveyard.rs
+++ b/pallets/utxo-nft/src/graveyard.rs
@@ -1,6 +1,5 @@
-use codec::MaxEncodedLen;
-use codec::{Decode, Encode};
 use frame_support::RuntimeDebug;
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 
 #[derive(Encode, Decode, Default, RuntimeDebug, MaxEncodedLen, TypeInfo, Clone, PartialEq)]

--- a/pallets/utxo-nft/src/lib.rs
+++ b/pallets/utxo-nft/src/lib.rs
@@ -1,6 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use codec::{Codec, MaxEncodedLen};
 use dscp_pallet_traits as traits;
 use dscp_pallet_traits::{ProcessFullyQualifiedId, ProcessValidator, ValidateProcessWeights};
 use frame_support::{
@@ -8,6 +7,7 @@ use frame_support::{
     BoundedVec,
 };
 pub use pallet::*;
+use parity_scale_codec::{Codec, MaxEncodedLen};
 use sp_runtime::traits::{AtLeast32Bit, Hash, One};
 
 /// A FRAME pallet for handling non-fungible tokens

--- a/pallets/utxo-nft/src/output.rs
+++ b/pallets/utxo-nft/src/output.rs
@@ -1,6 +1,5 @@
-use codec::{Decode, Encode};
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 
-use frame_support::codec::MaxEncodedLen;
 use frame_support::{traits::Get, BoundedBTreeMap};
 use scale_info::TypeInfo;
 use sp_std::prelude::*;

--- a/pallets/utxo-nft/src/tests/mock.rs
+++ b/pallets/utxo-nft/src/tests/mock.rs
@@ -1,13 +1,13 @@
 // Creating mock runtime here
 
 use crate as pallet_utxo_nft;
-use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{
     parameter_types,
     traits::{ConstU32, ConstU64, Hooks},
     weights::{constants::WEIGHT_REF_TIME_PER_SECOND, Weight},
 };
 use frame_system as system;
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 use sp_core::H256;
 use sp_runtime::{

--- a/pallets/utxo-nft/src/token.rs
+++ b/pallets/utxo-nft/src/token.rs
@@ -1,7 +1,6 @@
-use codec::MaxEncodedLen;
-use codec::{Decode, Encode};
 use frame_support::RuntimeDebug;
 use frame_support::{traits::Get, BoundedBTreeMap, BoundedVec};
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 
 /// A FRAME pallet for handling non-fungible tokens

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dscp-node-runtime"
-version = "9.3.0"
+version = "9.3.1"
 authors = ["Digital Catapult <https://www.digicatapult.org.uk>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -11,65 +11,59 @@ repository = "https://github.com/digicatapult/dscp-node/"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = [
-    "derive",
-] }
-scale-info = { version = "2.5.0", default-features = false, features = [
-    "derive",
-] }
+parity-scale-codec = { workspace = true }
+scale-info = { workspace = true }
 
-pallet-babe = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-pallet-balances = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-pallet-grandpa = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-pallet-sudo = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-frame-try-runtime = { version = "0.10.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", optional = true, branch = "polkadot-v0.9.42" }
-pallet-timestamp = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-pallet-transaction-payment-rpc-runtime-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-frame-executive = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-block-builder = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-consensus-babe = { version = "0.10.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-consensus-grandpa = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-core = { version = "7.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-inherents = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-offchain = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-runtime = { version = "7.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-session = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-std = { version = "5.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-transaction-pool = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-version = { version = "5.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+pallet-babe = { workspace = true }
+pallet-balances = { workspace = true }
+frame-support = { workspace = true }
+pallet-grandpa = { workspace = true }
+pallet-sudo = { workspace = true }
+frame-system = { workspace = true }
+pallet-timestamp = { workspace = true }
+pallet-transaction-payment-rpc-runtime-api = { workspace = true }
+frame-executive = { workspace = true }
+sp-api = { workspace = true }
+sp-block-builder = { workspace = true }
+sp-consensus-babe = { workspace = true }
+sp-consensus-grandpa = { workspace = true }
+sp-core = { workspace = true }
+sp-inherents = { workspace = true }
+sp-offchain = { workspace = true }
+sp-runtime = { workspace = true }
+sp-session = { workspace = true }
+sp-std = { workspace = true }
+sp-transaction-pool = { workspace = true }
+sp-version = { workspace = true }
+frame-try-runtime = { workspace = true, optional = true }
 
 # Dependencies not in node template
-pallet-collective = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-pallet-membership = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-pallet-node-authorization = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-pallet-preimage = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-pallet-scheduler = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-strum = { version = "0.24.1", features = [] }
-strum_macros = { version = "0.24.3", features = [] }
+pallet-collective = { workspace = true }
+pallet-membership = { workspace = true }
+pallet-node-authorization = { workspace = true }
+pallet-preimage = { workspace = true }
+pallet-scheduler = { workspace = true }
 
 # Used for the node template's RPCs
-frame-system-rpc-runtime-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+frame-system-rpc-runtime-api = { workspace = true }
 
 # Used for runtime benchmarking
-frame-benchmarking = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", optional = true, branch = "polkadot-v0.9.42" }
-frame-system-benchmarking = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", optional = true, branch = "polkadot-v0.9.42" }
-hex-literal = { version = "0.3.4", optional = true }
+frame-benchmarking = { workspace = true, optional = true }
+frame-system-benchmarking = { workspace = true, optional = true }
+hex-literal = { workspace = true, optional = true }
 
 # Local Dependencies
-pallet-doas = { default-features = false, package = 'pallet-doas', path = '../pallets/doas' }
-pallet-utxo-nft = { default-features = false, package = 'pallet-utxo-nft', path = '../pallets/utxo-nft' }
-pallet-process-validation = { default-features = false, package = 'pallet-process-validation', path = '../pallets/process-validation' }
-pallet-symmetric-key = { default-features = false, package = 'pallet-symmetric-key', path = '../pallets/symmetric-key' }
-pallet-transaction-payment-free = { default-features = false, package = 'pallet-transaction-payment-free', path = '../pallets/transaction-payment-free' }
-dscp-runtime-types = { default-features = false, package = "dscp-runtime-types", path = './types' }
+pallet-doas = { default-features = false, path = '../pallets/doas' }
+pallet-utxo-nft = { default-features = false, path = '../pallets/utxo-nft' }
+pallet-process-validation = { default-features = false, path = '../pallets/process-validation' }
+pallet-symmetric-key = { default-features = false, path = '../pallets/symmetric-key' }
+pallet-transaction-payment-free = { default-features = false, path = '../pallets/transaction-payment-free' }
+dscp-runtime-types = { default-features = false, path = './types' }
 
-serde = { version = "1.0.159" }
+serde = { workspace = true }
 
 [build-dependencies]
-substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+substrate-wasm-builder = { workspace = true }
 
 [features]
 default = ["std"]
@@ -77,13 +71,12 @@ std = [
     "frame-try-runtime?/std",
     "frame-system-benchmarking?/std",
     "frame-benchmarking?/std",
-    "codec/std",
+    "parity-scale-codec/std",
     "scale-info/std",
     "frame-executive/std",
     "frame-support/std",
     "frame-system-rpc-runtime-api/std",
     "frame-system/std",
-    "frame-try-runtime/std",
     "pallet-babe/std",
     "pallet-balances/std",
     "pallet-collective/std",

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -78,7 +78,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("dscp"),
     impl_name: create_runtime_str!("dscp"),
     authoring_version: 1,
-    spec_version: 930,
+    spec_version: 931,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/types/Cargo.toml
+++ b/runtime/types/Cargo.toml
@@ -5,31 +5,27 @@ edition = '2021'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/dscp-node/'
 name = 'dscp-runtime-types'
-version = "1.0.0"
+version = "1.0.1"
 
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
-serde = { version = "1.0.159", optional = true }
-scale-info = { version = "2.5.0", default-features = false, features = [
-    "derive",
-] }
-codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = [
-    "derive",
-] }
-frame-support = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-core = { version = "7.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-runtime = { default-features = false, version = "7.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+serde = { workspace = true, optional = true }
+scale-info = { workspace = true }
+parity-scale-codec = { workspace = true }
+frame-support = { workspace = true }
+sp-core = { workspace = true }
+sp-runtime = { workspace = true }
 strum = { version = "0.24.1", features = [] }
 strum_macros = { version = "0.24.3", features = [] }
 
-pallet-process-validation = { default-features = false, package = 'pallet-process-validation', path = '../../pallets/process-validation' }
+pallet-process-validation = { default-features = false, path = '../../pallets/process-validation' }
 
 [features]
 default = ['std']
 std = [
-    'codec/std',
+    'parity-scale-codec/std',
     'frame-support/std',
     'sp-core/std',
     'sp-runtime/std',

--- a/runtime/types/src/lib.rs
+++ b/runtime/types/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use codec::{Decode, Encode, MaxEncodedLen};
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{traits::ConstU32, BoundedVec};
 use scale_info::TypeInfo;
 use sp_runtime::{

--- a/runtime/types/src/lib.rs
+++ b/runtime/types/src/lib.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{traits::ConstU32, BoundedVec};
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 use sp_runtime::{
     traits::{IdentifyAccount, Verify},

--- a/tools/lang/Cargo.toml
+++ b/tools/lang/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dscp-lang"
 authors = ['Digital Catapult <https://www.digicatapult.org.uk>']
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [lib]
@@ -13,12 +13,13 @@ name = "dscp-lang"
 path = "src/main.rs"
 
 [dependencies]
-clap = { version = "4.4.6", features = ["derive"] }
-exitcode = "1.1.2"
-lazy_static = "1.4.0"
-pest = "2.6"
-pest_derive = "2.6"
+serde = { workspace = true }
+serde_json = { workspace = true }
+clap = { workspace = true }
+exitcode = { workspace = true }
+lazy_static = { workspace = true }
+pest = { workspace = true }
+pest_derive = { workspace = true }
+thiserror = { workspace = true }
+
 dscp-runtime-types = { path = '../../runtime/types' }
-serde = { version = "1.0.189" }
-serde_json = { version = "1.0.107" }
-thiserror = { version = "1.0.50" }


### PR DESCRIPTION
Re-organises our dpeendencies into the workspace `Cargo.toml` so that we can refer to consistent versions everywhere. This should make it easier for us to upgrade dependencies (especially substrate deps) in the future. 

Note this doesn't upgrade any dependencies or change nay code other than some package renames. Hence no benchmark updates