### PR TITLE
Add healthcheck to Dockerfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1957,7 +1957,7 @@ dependencies = [
 
 [[package]]
 name = "dscp-node"
-version = "10.0.3"
+version = "10.0.5"
 dependencies = [
  "async-trait",
  "bs58 0.5.0",
@@ -2010,7 +2010,7 @@ dependencies = [
 
 [[package]]
 name = "dscp-node-runtime"
-version = "10.0.3"
+version = "10.0.5"
 dependencies = [
  "dscp-runtime-types",
  "frame-benchmarking",

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ FROM ubuntu:jammy AS runtime
 
 RUN <<EOF
 apt-get update
-apt-get install -y libgcc-11-dev
+apt-get install -y libgcc-11-dev curl
 rm -rf /var/lib/apt/lists/*
 EOF
 
@@ -53,4 +53,6 @@ WORKDIR /dscp-node
 
 ENTRYPOINT [ "/dscp-node/dscp-node" ]
 
-EXPOSE 30333 9933 9944
+HEALTHCHECK CMD curl -f http://localhost:9944/health || exit 1
+
+EXPOSE 30333 9615 9944

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -6,7 +6,7 @@ edition = '2021'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/dscp-node/'
 name = 'dscp-node'
-version = '10.0.4'
+version = '10.0.5'
 
 [[bin]]
 name = 'dscp-node'

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dscp-node-runtime"
-version = "10.0.4"
+version = "10.0.5"
 authors = ["Digital Catapult <https://www.digicatapult.org.uk>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
Adds a healthcheck to the Dockerfile so that we can orchestrate the order in which services start in our docker compose files